### PR TITLE
Disable crashing attribution

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -17,7 +17,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class MapboxMapBuilder implements MapboxMapOptionsSink {
   public final String TAG = getClass().getSimpleName();
-  private final MapboxMapOptions options = new MapboxMapOptions().textureMode(true);
+  private final MapboxMapOptions options = new MapboxMapOptions()
+    .textureMode(true)
+    .attributionEnabled(false);
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
 


### PR DESCRIPTION
In the Mapbox Maps SDK for Android we will show an Android SDK Dialog when clicking on the i-icon on the map. This behaviour is not supported while integrating a platform Android View inside as a flutter widget. We need to replace this interaction with using a Flutter component instead.

cc @yoavrofe 