### PR TITLE
[flutter] - add supported API table to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Add these lines to your Info.plist
 <string>YOUR_TOKEN_HERE</string>
 ```
 
+## Supported API
+
+| Feature | Android | iOS |
+| ------ | ------ | ----- |
+| Style | :white_check_mark:   | :white_check_mark: |
+| Camera | :white_check_mark:   | :white_check_mark: |
+| Gesture | :white_check_mark:   | :white_check_mark: |
+| User Location | :white_check_mark:   | |
+| Symbol | :white_check_mark:   | |
+| Circle | :white_check_mark:   |  |
+| Line | :white_check_mark:   |  |
+| Fill |   |  |
+
 
 ## Documentation
 


### PR DESCRIPTION
This PR adds a simplistic supported API table to the readme. 