### PR TITLE
Specify Swift version in mapbox_gl.podspec

### DIFF
--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -18,5 +18,6 @@ A new Flutter plugin.
   s.dependency 'Mapbox-iOS-SDK', '~> 4.8.0'
 
   s.ios.deployment_target = '9.0'
+  s.swift_version = '5.0'
 end
 


### PR DESCRIPTION
As detailed in my [issue](https://github.com/tobrun/flutter-mapbox-gl/issues/55), pod install fails unless Swift version is specified in mapbox_gl.podspec.

Adding the SWIFT_VERSION to Podfile (as done in [this commit](https://github.com/tobrun/flutter-mapbox-gl/pull/18/commits/392e37342852fc5007e0d2ce311dab24255f5994)) still results in the following error:

```
Unable to determine Swift version for the following pods:
    - `mapbox_gl` does not specify a Swift version and none of the targets (`Runner`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

As for the actual Swift version to use, I'll leave that up to you guys :)