### PR TITLE
Invert iOS compassView.isHidden logic

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -126,6 +126,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     }
     func setCompassEnabled(compassEnabled: Bool) {
         mapView.compassView.isHidden = compassEnabled
+        mapView.compassView.isHidden = !compassEnabled
     }
     func setMinMaxZoomPreference(min: Double, max: Double) {
         mapView.minimumZoomLevel = min

--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -18,5 +18,6 @@ A new Flutter plugin.
   s.dependency 'Mapbox-iOS-SDK', '~> 4.8.0'
 
   s.ios.deployment_target = '9.0'
+  s.swift_version = '5.0'
 end
 

--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -18,6 +18,5 @@ A new Flutter plugin.
   s.dependency 'Mapbox-iOS-SDK', '~> 4.8.0'
 
   s.ios.deployment_target = '9.0'
-  s.swift_version = '5.0'
 end
 


### PR DESCRIPTION
If the map compass is enabled (which it should be by default), `mapView.compassView.isHidden` should be set to the inverse of `compassEnabled` (line 128 of ios/Classes/MapboxMapController.swift). Right now, `mapView.compassView.isHidden` is set to the value of `compassEnabled`, which hides the compass when it should be visible.