### PR TITLE
new future->mapboxMapController.getCircleLatLng，get real-time location for circle

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/CircleController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/CircleController.java
@@ -75,6 +75,11 @@ class CircleController implements CircleOptionsSink {
     circle.setGeometry(Point.fromLngLat(geometry.getLongitude(), geometry.getLatitude()));
   }
 
+  public LatLng getGeometry() {
+    Point point =  circle.getGeometry();
+    return new LatLng(point.latitude(), point.longitude());
+  }
+
   @Override
   public void setDraggable(boolean draggable) {
     circle.setDraggable(draggable);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -470,6 +470,16 @@ final class MapboxMapController
         result.success(null);
         break;
       }
+      case "circle#getGeometry": {
+        final String circleId = call.argument("circle");
+        final CircleController circle = circle(circleId);
+        final LatLng circleLatLng = circle.getGeometry();
+        Map<String, Double> hashMapLatLng = new HashMap<>();
+        hashMapLatLng.put("latitude", circleLatLng.getLatitude());
+        hashMapLatLng.put("longitude", circleLatLng.getLongitude());
+        result.success(hashMapLatLng);
+        break;
+      }
       default:
         result.notImplemented();
     }

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -116,6 +116,15 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
     );
   }
 
+  void _getLatLng() async {
+    LatLng latLng = await controller.getCircleLatLng(_selectedCircle);
+    Scaffold.of(context).showSnackBar(
+      SnackBar(
+        content: Text(latLng.toString()),
+      ),
+    );
+  }
+
   void _changeCircleStrokeOpacity() {
     double current = _selectedCircle.options.circleStrokeOpacity;
     if (current == null) {
@@ -285,6 +294,12 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                           onPressed: (_selectedCircle == null)
                               ? null
                               : _changeDraggable,
+                        ),
+                        FlatButton(
+                          child: const Text('get current LatLng'),
+                          onPressed: (_selectedCircle == null)
+                              ? null
+                              : _getLatLng,
                         ),
                       ],
                     ),

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -399,6 +399,19 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// `circle.options.geometry` can't get real-time location.For example, when you
+  /// set circle `draggable` is true,and you dragged circle.At this time you
+  /// should use `getCircleLatLng()`
+  Future<LatLng> getCircleLatLng(Circle circle) async {
+    assert(circle != null);
+    assert(_circles[circle._id] == circle);
+    Map mapLatLng = await _channel.invokeMethod('circle#getGeometry', <String, dynamic>{
+      'circle': circle._id,
+    });
+    LatLng circleLatLng = new LatLng(mapLatLng['latitude'], mapLatLng['longitude']);
+    notifyListeners();
+    return circleLatLng;
+  }
 
   /// Removes the specified [circle] from the map. The circle must be a current
   /// member of the [circles] set.


### PR DESCRIPTION
sorry, I have been delaying for so long.

`circle.options.geometry` can't get real-time location.For example, when you set circle `draggable` is true,and you dragged circle.At this time you should use `getCircleLatLng()`

 #78 

(cherry picked from commit c75dfa5270501c6605ebb1aa5c319e44edfaa103)