### PR TITLE
Implement iOS annotation extension (rework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Add these lines to your Info.plist
 | Camera | :white_check_mark:   | :white_check_mark: |
 | Gesture | :white_check_mark:   | :white_check_mark: |
 | User Location | :white_check_mark: | :white_check_mark: |
-| Symbol | :white_check_mark:   | |
-| Circle | :white_check_mark:   |  |
-| Line | :white_check_mark:   |  |
+| Symbol | :white_check_mark:   | :white_check_mark: |
+| Circle | :white_check_mark:   | :white_check_mark: |
+| Line | :white_check_mark:   | :white_check_mark: |
 | Fill |   |  |
 
 ## Offline Sideloading

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -264,6 +264,8 @@
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/F6FDF133-0198-394E-9C8F-5043F94B4790.bcsymbolmap",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/B4615DAE-86F8-35AB-B4D1-B1F1420E374A.bcsymbolmap",
+				"${BUILT_PRODUCTS_DIR}/MapboxAnnotationExtension/MapboxAnnotationExtension.framework",
+				"${BUILT_PRODUCTS_DIR}/location/location.framework",
 				"${BUILT_PRODUCTS_DIR}/mapbox_gl/mapbox_gl.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -273,6 +275,8 @@
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/F6FDF133-0198-394E-9C8F-5043F94B4790.bcsymbolmap",
 				"${BUILT_PRODUCTS_DIR}/B4615DAE-86F8-35AB-B4D1-B1F1420E374A.bcsymbolmap",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxAnnotationExtension.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/location.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mapbox_gl.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -104,7 +104,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     );
   }
 
-  void _changeAnchor() {
+  void _changeIconOffset() {
     Offset currentAnchor = _selectedSymbol.options.iconOffset;
     if (currentAnchor == null) {
       // default value
@@ -112,6 +112,18 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     }
     final Offset newAnchor = Offset(1.0 - currentAnchor.dy, currentAnchor.dx);
     _updateSelectedSymbol(SymbolOptions(iconOffset: newAnchor));
+  }
+
+  Future<void> _changeIconAnchor() async {
+    String current = _selectedSymbol.options.iconAnchor;
+    if (current == null || current == 'center') {
+      current = 'bottom';
+    } else {
+      current = 'center';
+    }
+    _updateSelectedSymbol(
+      SymbolOptions(iconAnchor: current),
+    );
   }
 
   Future<void> _toggleDraggable() async {
@@ -225,9 +237,15 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                               (_selectedSymbol == null) ? null : _changeAlpha,
                         ),
                         FlatButton(
-                          child: const Text('change anchor'),
+                          child: const Text('change icon offset'),
                           onPressed:
-                              (_selectedSymbol == null) ? null : _changeAnchor,
+                              (_selectedSymbol == null) ? null : _changeIconOffset,
+                        ),
+                        FlatButton(
+                          child: const Text('change icon anchor'),
+                          onPressed: (_selectedSymbol == null)
+                              ? null
+                              : _changeIconAnchor,
                         ),
                         FlatButton(
                           child: const Text('toggle draggable'),

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -25,4 +25,16 @@ class Constants {
         "left": MGLTextJustification.left,
         "right": MGLTextJustification.right
     ]
+    
+    static let symbolTextAnchorMapping = [
+        "center": MGLTextAnchor.center,
+        "left": MGLTextAnchor.left,
+        "right": MGLTextAnchor.right,
+        "top": MGLTextAnchor.top,
+        "bottom": MGLTextAnchor.bottom,
+        "top-left": MGLTextAnchor.topLeft,
+        "top-right": MGLTextAnchor.topRight,
+        "bottom-left": MGLTextAnchor.bottomLeft,
+        "bottom-right": MGLTextAnchor.bottomRight
+    ]
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -43,4 +43,10 @@ class Constants {
         "lowercase": MGLTextTransform.lowercase,
         "uppercase": MGLTextTransform.uppercase
     ]
+    
+    static let lineJoinMapping = [
+        "bevel": MGLLineJoin.bevel,
+        "miter": MGLLineJoin.miter,
+        "round": MGLLineJoin.round
+    ]
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -16,6 +16,6 @@ class Constants {
         "top-left": MGLIconAnchor.topLeft,
         "top-right": MGLIconAnchor.topRight,
         "bottom-left": MGLIconAnchor.bottomLeft,
-        "right": MGLIconAnchor.bottomRight
+        "bottom-right": MGLIconAnchor.bottomRight
     ]
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -18,4 +18,11 @@ class Constants {
         "bottom-left": MGLIconAnchor.bottomLeft,
         "bottom-right": MGLIconAnchor.bottomRight
     ]
+    
+    static let symbolTextJustificationMapping = [
+        "auto": MGLTextJustification.auto,
+        "center": MGLTextJustification.center,
+        "left": MGLTextJustification.left,
+        "right": MGLTextJustification.right
+    ]
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -37,4 +37,10 @@ class Constants {
         "bottom-left": MGLTextAnchor.bottomLeft,
         "bottom-right": MGLTextAnchor.bottomRight
     ]
+    
+    static let symbolTextTransformationMapping = [
+        "none": MGLTextTransform.none,
+        "lowercase": MGLTextTransform.lowercase,
+        "uppercase": MGLTextTransform.uppercase
+    ]
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -1,0 +1,21 @@
+import Mapbox
+import MapboxAnnotationExtension
+
+/*
+ * The mapping is based on the values defined here:
+ *  https://docs.mapbox.com/android/api/map-sdk/8.4.0/constant-values.html
+ */
+
+class Constants {
+    static let symbolIconAnchorMapping = [
+        "center": MGLIconAnchor.center,
+        "left": MGLIconAnchor.left,
+        "right": MGLIconAnchor.right,
+        "top": MGLIconAnchor.top,
+        "bottom": MGLIconAnchor.bottom,
+        "top-left": MGLIconAnchor.topLeft,
+        "top-right": MGLIconAnchor.topRight,
+        "bottom-left": MGLIconAnchor.bottomLeft,
+        "right": MGLIconAnchor.bottomRight
+    ]
+}

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -201,10 +201,9 @@ class Convert {
                 delegate.textTransform = MGLTextTransform.none
             }
         }
-        //TODO: How to parse the offset to CGVector.
-        //        if let textOffset = options["textOffset"] as? String {
-        //            delegate.textOffset = textOffset
-        //        }
+        if let textOffset = options["textOffset"] as? [Double] {
+            delegate.textOffset = CGVector(dx: textOffset[0], dy: textOffset[1])
+        }
         if let textOpacity = options["textOpacity"] as? CGFloat {
             delegate.textOpacity = textOpacity
         }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -273,8 +273,12 @@ class Convert {
     class func interpretLineOptions(options: Any?, delegate: MGLLineStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
         
-        if let lineJoin = options["lineJoin"] as? String {
-            //TODO: Parse string to enum
+        if let lineJoinStr = options["lineJoin"] as? String {
+            if let lineJoin = Constants.lineJoinMapping[lineJoinStr] {
+                delegate.lineJoin = lineJoin
+            } else {
+                delegate.lineJoin = MGLLineJoin.miter
+            }
         }
         if let lineOpacity = options["lineOpacity"] as? CGFloat {
             delegate.lineOpacity = lineOpacity

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -273,6 +273,32 @@ class Convert {
     class func interpretLineOptions(options: Any?, delegate: MGLLineStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
         
-        //TODO: implement line options.
+        if let lineJoin = options["lineJoin"] as? String {
+            //TODO: Parse string to enum
+        }
+        if let lineOpacity = options["lineOpacity"] as? CGFloat {
+            delegate.lineOpacity = lineOpacity
+        }
+        if let lineColor = options["lineColor"] as? String {
+            delegate.lineColor = UIColor(hexString: lineColor) ?? UIColor.black
+        }
+        if let lineWidth = options["lineWidth"] as? CGFloat {
+            delegate.lineWidth = lineWidth
+        }
+        if let lineGapWidth = options["lineGapWidth"] as? CGFloat {
+            delegate.lineGapWidth = lineGapWidth
+        }
+        if let lineOffset = options["lineOffset"] as? CGFloat {
+            delegate.lineOffset = lineOffset
+        }
+        if let lineBlur = options["lineBlur"] as? CGFloat {
+            delegate.lineBlur = lineBlur
+        }
+        if let linePattern = options["linePattern"] as? String {
+            delegate.linePattern = linePattern
+        }
+        if let draggable = options["draggable"] as? Bool {
+            delegate.isDraggable = draggable
+        }
     }
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -195,7 +195,11 @@ class Convert {
             delegate.textRotation = textRotate
         }
         if let textTransform = options["textTransform"] as? String {
-            //TODO: Parse textTransform
+            if let textTransformation = Constants.symbolTextTransformationMapping[textTransform] {
+                delegate.textTransform = textTransformation
+            } else {
+                delegate.textTransform = MGLTextTransform.none
+            }
         }
         //TODO: How to parse the offset to CGVector.
         //        if let textOffset = options["textOffset"] as? String {

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -237,4 +237,10 @@ class Convert {
             delegate.isDraggable = draggable
         }
     }
+    
+    class func interpretCircleOptions(options: Any?, delegate: MGLCircleStyleAnnotation) {
+        guard let options = options as? [String: Any] else { return }
+    
+        //TODO: Implement mapping between options and annotation.
+    }
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -141,7 +141,11 @@ class Convert {
             delegate.iconOffset = CGVector(dx: iconOffset[0], dy: iconOffset[1])
         }
         if let iconAnchorStr = options["iconAnchor"] as? String {
-            //TODO: mapping
+            if let iconAnchor = Constants.symbolIconAnchorMapping[iconAnchorStr] {
+                delegate.iconAnchor = iconAnchor
+            } else {
+                delegate.iconAnchor = MGLIconAnchor.center
+            }
         }
         if let iconOpacity = options["iconOpacity"] as? CGFloat {
             delegate.iconOpacity = iconOpacity

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -177,7 +177,7 @@ class Convert {
             if let textJustifaction = Constants.symbolTextJustificationMapping[textJustify] {
                 delegate.textJustification = textJustifaction
             } else {
-                delegate.textJustification = MGLTextJustification.auto
+                delegate.textJustification = MGLTextJustification.center
             }
         }
         if let textRadialOffset = options["textRadialOffset"] as? CGFloat {

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -184,8 +184,12 @@ class Convert {
         if let textRadialOffset = options["textRadialOffset"] as? CGFloat {
             delegate.textRadialOffset = textRadialOffset
         }
-        if let textAnchor = options["textAnchor"] as? String {
-            //TODO: Parse textAnchor
+        if let textAnchorStr = options["textAnchor"] as? String {
+            if let textAnchor = Constants.symbolTextAnchorMapping[textAnchorStr] {
+                delegate.textAnchor = textAnchor
+            } else {
+                delegate.textAnchor = MGLTextAnchor.center
+            }
         }
         if let textRotate = options["textRotate"] as? CGFloat {
             delegate.textRotation = textRotate

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -201,6 +201,9 @@ class Convert {
                 delegate.textTransform = MGLTextTransform.none
             }
         }
+        if let textTranslate = options["textTranslate"] as? [Double] {
+            delegate.textTranslation = CGVector(dx: textTranslate[0], dy: textTranslate[1])
+        }
         if let textOffset = options["textOffset"] as? [Double] {
             delegate.textOffset = CGVector(dx: textOffset[0], dy: textOffset[1])
         }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -175,7 +175,11 @@ class Convert {
             delegate.textLetterSpacing = textLetterSpacing
         }
         if let textJustify = options["textJustify"] as? String {
-            //TODO: Parse textJustify
+            if let textJustifaction = Constants.symbolTextJustificationMapping[textJustify] {
+                delegate.textJustification = textJustifaction
+            } else {
+                delegate.textJustification = MGLTextJustification.auto
+            }
         }
         //TODO: textRadialOffset
         if let textAnchor = options["textAnchor"] as? String {

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -181,7 +181,9 @@ class Convert {
                 delegate.textJustification = MGLTextJustification.auto
             }
         }
-        //TODO: textRadialOffset
+        if let textRadialOffset = options["textRadialOffset"] as? CGFloat {
+            delegate.textRadialOffset = textRadialOffset
+        }
         if let textAnchor = options["textAnchor"] as? String {
             //TODO: Parse textAnchor
         }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -240,7 +240,33 @@ class Convert {
     
     class func interpretCircleOptions(options: Any?, delegate: MGLCircleStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
-    
-        //TODO: Implement mapping between options and annotation.
+        
+        if let circleRadius = options["circleRadius"] as? CGFloat {
+            delegate.circleRadius = circleRadius
+        }
+        if let circleColor = options["circleColor"] as? String {
+            delegate.circleColor = UIColor(hexString: circleColor) ?? UIColor.black
+        }
+        if let circleBlur = options["circleBlur"] as? CGFloat {
+            delegate.circleBlur = circleBlur
+        }
+        if let circleOpacity = options["circleOpacity"] as? CGFloat {
+            delegate.circleOpacity = circleOpacity
+        }
+        if let circleStrokeWidth = options["circleStrokeWidth"] as? CGFloat {
+            delegate.circleStrokeWidth = circleStrokeWidth
+        }
+        if let circleStrokeColor = options["circleStrokeColor"] as? String {
+            delegate.circleStrokeColor = UIColor(hexString: circleStrokeColor) ?? UIColor.black
+        }
+        if let circleStrokeOpacity = options["circleStrokeOpacity"] as? CGFloat {
+            delegate.circleStrokeOpacity = circleStrokeOpacity
+        }
+        if let geometry = options["geometry"] as? [Double] {
+            delegate.center = CLLocationCoordinate2DMake(geometry[0], geometry[1])
+        }
+        if let draggable = options["draggable"] as? Bool {
+            delegate.isDraggable = draggable
+        }
     }
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -269,4 +269,10 @@ class Convert {
             delegate.isDraggable = draggable
         }
     }
+    
+    class func interpretLineOptions(options: Any?, delegate: MGLLineStyleAnnotation) {
+        guard let options = options as? [String: Any] else { return }
+        
+        //TODO: implement line options.
+    }
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -1,4 +1,5 @@
 import Mapbox
+import MapboxAnnotationExtension
 
 class Convert {
     class func interpretMapboxMapOptions(options: Any?, delegate: MapboxMapOptionsSink) {
@@ -124,85 +125,34 @@ class Convert {
         return MGLAltitudeForZoomLevel(zoom, mapView.camera.pitch, mapView.camera.centerCoordinate.latitude, mapView.frame.size)
     }
 
-    class func interpretSymbolOptions(options: Any?, delegate: SymbolOptionsSink) {
+    class func interpretSymbolOptions(options: Any?, delegate: MGLSymbolStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
         
-        if let iconSize = options["iconSize"] as? Double {
-            delegate.setIconSize(iconSize: iconSize)
-        }
         if let iconImage = options["iconImage"] as? String {
-            delegate.setIconImage(iconImage: iconImage)
+            delegate.iconImageName = iconImage
         }
-        if let iconRotate = options["iconRotate"] as? Double {
-            delegate.setIconRotate(iconRotate: iconRotate)
+        if let iconRotate = options["iconRotate"] as? CGFloat {
+            delegate.iconRotation = iconRotate
         }
-        //TODO: iconOffset
-        if let iconAnchor = options["iconAnchor"] as? String {
-            delegate.setIconAnchor(iconAnchor: iconAnchor)
+        if let iconOffset = options["iconOffset"] as? [Double] {
+            delegate.iconOffset = CGVector(dx: iconOffset[0], dy: iconOffset[1])
         }
-        if let textField = options["textField"] as? String {
-            delegate.setTextField(textField: textField)
-        }
-        if let textSize = options["textSize"] as? Double {
-            delegate.setTextSize(textSize: textSize)
-        }
-        if let textMaxWidth = options["textMaxWidth"] as? Double {
-            delegate.setTextMaxWidth(textMaxWidth: textMaxWidth)
-        }
-        if let textLetterSpacing = options["textLetterSpacing"] as? Double {
-            delegate.setTextLetterSpacing(textLetterSpacing: textLetterSpacing)
-        }
-        if let textJustify = options["textJustify"] as? String {
-            delegate.setTextJustify(textJustify: textJustify)
-        }
-        if let textAnchor = options["textAnchor"] as? String {
-            delegate.setTextAnchor(textAnchor: textAnchor)
-        }
-        if let textRotate = options["textRotate"] as? Double {
-            delegate.setTextRotate(textRotate: textRotate)
-        }
-        if let textTransform = options["textTransform"] as? String {
-            delegate.setTextTransform(textTransform: textTransform)
-        }
-        //TODO: textOffset
-        if let iconOpacity = options["iconOpacity"] as? Double {
-            delegate.setIconOpacity(iconOpacity: iconOpacity)
-        }
-        if let iconColor = options["iconColor"] as? String {
-            delegate.setIconColor(iconColor: iconColor)
-        }
-        if let iconHaloColor = options["iconHaloColor"] as? String {
-            delegate.setIconHaloColor(iconHaloColor: iconHaloColor)
-        }
-        if let iconHaloWidth = options["iconHaloWidth"] as? Double {
-            delegate.setIconHaloWidth(iconHaloWidth: iconHaloWidth)
-        }
-        if let iconHaloBlur = options["iconHaloBlur"] as? Double {
-            delegate.setIconHaloBlur(iconHaloBlur: iconHaloBlur)
-        }
-        if let textOpacity = options["textOpacity"] as? Double {
-            delegate.setTextOpacity(textOpacity: textOpacity)
-        }
-        if let textColor = options["textColor"] as? String {
-            delegate.setTextColor(textColor: textColor)
-        }
-        if let textHaloColor = options["textHaloColor"] as? String {
-            delegate.setTextHaloColor(textHaloColor: textHaloColor)
-        }
-        if let textHaloWidth = options["textHaloWidth"] as? Double {
-            delegate.setTextHaloWidth(textHaloWidth: textHaloWidth)
-        }
-        if let textHaloBlur = options["textHaloBlur"] as? Double {
-            delegate.setTextHaloBlur(textHaloBlur: textHaloBlur)
+        if let iconOpacity = options["iconOpacity"] as? CGFloat {
+            delegate.iconOpacity = iconOpacity
         }
         if let geometry = options["geometry"] as? [Double] {
-            delegate.setGeometry(geometry: geometry)
+            // We cannot set the geometry directy on the annotation so calculate
+            // the difference and update the coordinate using the delta.
+            let currCoord = delegate.feature.coordinate
+            let newCoord = CLLocationCoordinate2DMake(geometry[0], geometry[1])
+            let delta = CGVector(dx: newCoord.longitude - currCoord.longitude, dy: newCoord.latitude - currCoord.latitude)
+            delegate.updateGeometryCoordinates(withDelta: delta)
         }
         if let zIndex = options["zIndex"] as? Int {
-            delegate.setZIndex(zIndex: zIndex)
+            delegate.symbolSortKey = zIndex
         }
         if let draggable = options["draggable"] as? Bool {
-            delegate.setDraggable(draggable: draggable)
+            delegate.isDraggable = draggable
         }
     }
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -147,10 +147,10 @@ class Convert {
             delegate.iconOpacity = iconOpacity
         }
         if let iconColor = options["iconColor"] as? String {
-            //TODO: parse color
+            delegate.iconColor = UIColor(hexString: iconColor) ?? UIColor.black
         }
         if let iconHaloColor = options["iconHaloColor"] as? String {
-            //TODO: parse color
+            delegate.iconHaloColor = UIColor(hexString: iconHaloColor) ?? UIColor.white
         }
         if let iconHaloWidth = options["iconHaloWidth"] as? CGFloat {
             delegate.iconHaloWidth = iconHaloWidth
@@ -191,10 +191,10 @@ class Convert {
             delegate.textOpacity = textOpacity
         }
         if let textColor = options["textColor"] as? String {
-            //TODO: parse color
+            delegate.textColor = UIColor(hexString: textColor) ?? UIColor.black
         }
         if let textHaloColor = options["textHaloColor"] as? String {
-            //TODO: parse color
+            delegate.textHaloColor = UIColor(hexString: textHaloColor) ?? UIColor.white
         }
         if let textHaloWidth = options["textHaloWidth"] as? CGFloat {
             delegate.textHaloWidth = textHaloWidth

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -127,7 +127,6 @@ class Convert {
 
     class func interpretSymbolOptions(options: Any?, delegate: MGLSymbolStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
-        
         if let iconSize = options["iconSize"] as? CGFloat {
             delegate.iconScale = iconSize
         }
@@ -240,7 +239,6 @@ class Convert {
     
     class func interpretCircleOptions(options: Any?, delegate: MGLCircleStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
-        
         if let circleRadius = options["circleRadius"] as? CGFloat {
             delegate.circleRadius = circleRadius
         }
@@ -272,7 +270,6 @@ class Convert {
     
     class func interpretLineOptions(options: Any?, delegate: MGLLineStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
-        
         if let lineJoinStr = options["lineJoin"] as? String {
             if let lineJoin = Constants.lineJoinMapping[lineJoinStr] {
                 delegate.lineJoin = lineJoin

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -128,6 +128,9 @@ class Convert {
     class func interpretSymbolOptions(options: Any?, delegate: MGLSymbolStyleAnnotation) {
         guard let options = options as? [String: Any] else { return }
         
+        if let iconSize = options["iconSize"] as? CGFloat {
+            delegate.iconScale = iconSize
+        }
         if let iconImage = options["iconImage"] as? String {
             delegate.iconImageName = iconImage
         }
@@ -137,8 +140,67 @@ class Convert {
         if let iconOffset = options["iconOffset"] as? [Double] {
             delegate.iconOffset = CGVector(dx: iconOffset[0], dy: iconOffset[1])
         }
+        if let iconAnchorStr = options["iconAnchor"] as? String {
+            //TODO: mapping
+        }
         if let iconOpacity = options["iconOpacity"] as? CGFloat {
             delegate.iconOpacity = iconOpacity
+        }
+        if let iconColor = options["iconColor"] as? String {
+            //TODO: parse color
+        }
+        if let iconHaloColor = options["iconHaloColor"] as? String {
+            //TODO: parse color
+        }
+        if let iconHaloWidth = options["iconHaloWidth"] as? CGFloat {
+            delegate.iconHaloWidth = iconHaloWidth
+        }
+        if let iconHaloBlur = options["iconHaloBlur"] as? CGFloat {
+            delegate.iconHaloBlur = iconHaloBlur
+        }
+        if let textField = options["textField"] as? String {
+            delegate.text = textField
+        }
+        if let textSize = options["textSize"] as? CGFloat {
+            delegate.textFontSize = textSize
+        }
+        if let textMaxWidth = options["textMaxWidth"] as? CGFloat {
+            delegate.maximumTextWidth = textMaxWidth
+        }
+        if let textLetterSpacing = options["textLetterSpacing"] as? CGFloat {
+            delegate.textLetterSpacing = textLetterSpacing
+        }
+        if let textJustify = options["textJustify"] as? String {
+            //TODO: Parse textJustify
+        }
+        //TODO: textRadialOffset
+        if let textAnchor = options["textAnchor"] as? String {
+            //TODO: Parse textAnchor
+        }
+        if let textRotate = options["textRotate"] as? CGFloat {
+            delegate.textRotation = textRotate
+        }
+        if let textTransform = options["textTransform"] as? String {
+            //TODO: Parse textTransform
+        }
+        //TODO: How to parse the offset to CGVector.
+        //        if let textOffset = options["textOffset"] as? String {
+        //            delegate.textOffset = textOffset
+        //        }
+        if let textOpacity = options["textOpacity"] as? CGFloat {
+            delegate.textOpacity = textOpacity
+        }
+        if let textColor = options["textColor"] as? String {
+            //TODO: parse color
+        }
+        if let textHaloColor = options["textHaloColor"] as? String {
+            //TODO: parse color
+        }
+        if let textHaloWidth = options["textHaloWidth"] as? CGFloat {
+            delegate.textHaloWidth = textHaloWidth
+        }
+        if let textHaloBlur = options["textHaloBlur"] as? CGFloat {
+            delegate.textHaloBlur = textHaloBlur
         }
         if let geometry = options["geometry"] as? [Double] {
             // We cannot set the geometry directy on the annotation so calculate

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -61,3 +61,31 @@ extension UIImage {
         return nil
     }
 }
+
+extension UIColor {
+    public convenience init?(hexString: String) {
+        let r, g, b, a: CGFloat
+        
+        if hexString.hasPrefix("#") {
+            let start = hexString.index(hexString.startIndex, offsetBy: 1)
+            let hexColor = hexString[start...]
+            
+            if hexColor.count == 6 {
+                let scanner = Scanner(string: String(hexColor))
+                var hexNumber: UInt64 = 0
+                
+                if scanner.scanHexInt64(&hexNumber) {
+                    r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
+                    g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
+                    b = CGFloat(hexNumber & 0x0000ff) / 255
+                    a = 255
+                    
+                    self.init(red: r, green: g, blue: b, alpha: a)
+                    return
+                }
+            }
+        }
+        
+        return nil
+    }
+}

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -97,10 +97,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "symbol#update":
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let symbolIdString = arguments["symbol"] as? String else { return }
+            guard let symbolId = arguments["symbol"] as? String else { return }
 
             for symbol in symbolAnnotationController.styleAnnotations(){
-                if symbol.identifier == symbolIdString {
+                if symbol.identifier == symbolId {
                     Convert.interpretSymbolOptions(options: arguments["options"], delegate: symbol as! MGLSymbolStyleAnnotation)
                     // Load (updated) icon image from asset if an icon name is supplied.
                     if let options = arguments["options"] as? [String: Any],
@@ -115,10 +115,10 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "symbol#remove":
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let symbolIdString = arguments["symbol"] as? String else { return }
+            guard let symbolId = arguments["symbol"] as? String else { return }
 
             for symbol in symbolAnnotationController.styleAnnotations(){
-                if symbol.identifier == symbolIdString {
+                if symbol.identifier == symbolId {
                     symbolAnnotationController.removeStyleAnnotation(symbol)
                     break;
                 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -142,6 +142,27 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     }
     
     /*
+     *  MGLAnnotationControllerDelegate
+     */
+    func annotationController(_ annotationController: MGLAnnotationController, didSelect styleAnnotation: MGLStyleAnnotation) {
+        guard let channel = channel else {
+            return
+        }
+        
+        if let symbol = styleAnnotation as? MGLSymbolStyleAnnotation {
+            channel.invokeMethod("symbol#onTap", arguments: ["symbol" : "\(symbol.identifier)"])
+        }
+    }
+    
+    // This is required in order to hide the default Maps SDK pin
+    func mapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+        if annotation is MGLUserLocation {
+            return MGLUserLocationAnnotationView()
+        }
+        return MGLAnnotationView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    }
+    
+    /*
      *  MGLMapViewDelegate
      */
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -205,6 +205,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         
         if let symbol = styleAnnotation as? MGLSymbolStyleAnnotation {
             channel.invokeMethod("symbol#onTap", arguments: ["symbol" : "\(symbol.identifier)"])
+        } else if let circle = styleAnnotation as? MGLCircleStyleAnnotation {
+            channel.invokeMethod("circle#onTap", arguments: ["circle" : "\(circle.identifier)"])
         }
     }
     

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -120,19 +120,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
     }
 
-    private func getSymbolInMapView(mapView: MGLMapView, symbolId: String) -> Symbol? {
-        if let annotations = mapView.annotations {
-            for (_, annotation) in annotations.enumerated() {
-                if let symbolAnnotation = annotation as? Symbol {
-                    if symbolAnnotation.id == symbolId {
-                        return symbolAnnotation
-                    }
-                }
-            }
-        }
-        return nil
-    }
-
     private func updateMyLocationEnabled() {
         mapView.showsUserLocation = self.myLocationEnabled
     }
@@ -201,46 +188,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         let intersects = MGLCoordinateInCoordinateBounds(newVisibleCoordinates.ne, bbox) && MGLCoordinateInCoordinateBounds(newVisibleCoordinates.sw, bbox)
         
         return inside && intersects
-    }
-    
-    func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        // Only for Symbols images should loaded.
-        guard let symbol = annotation as? Symbol,
-            let iconImageFullPath = symbol.iconImage else {
-                return nil
-        }
-        // Reuse existing annotations for better performance.
-        var annotationImage = mapView.dequeueReusableAnnotationImage(withIdentifier: iconImageFullPath)
-        if annotationImage == nil {
-            // Initialize the annotation image (from predefined assets symbol folder).
-            if let range = iconImageFullPath.range(of: "/", options: [.backwards]) {
-                let directory = String(iconImageFullPath[..<range.lowerBound])
-                let assetPath = registrar.lookupKey(forAsset: "\(directory)/")
-                let iconImageName = String(iconImageFullPath[range.upperBound...])
-                let image = UIImage.loadFromFile(imagePath: assetPath, imageName: iconImageName)
-                if let image = image {
-                    annotationImage = MGLAnnotationImage(image: image, reuseIdentifier: iconImageFullPath)
-                }
-            }
-        }
-        return annotationImage
-    }
-    
-    // On tap invoke the symbol#onTap callback.
-    func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
-        // Only for Symbols images should loaded.
-        guard let symbol = annotation as? Symbol else {
-            return
-        }
-        
-        if let channel = channel {
-            channel.invokeMethod("symbol#onTap", arguments: ["symbol" : "\(symbol.id)"])
-        }
-    }
-    
-    // Allow callout view to appear when an annotation is tapped.
-    func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
-        return true
     }
     
     func mapView(_ mapView: MGLMapView, didChange mode: MGLUserTrackingMode, animated: Bool) {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -134,7 +134,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 // Convert geometry to coordinate and create circle.
                 let coordinate = CLLocationCoordinate2DMake(geometry[0], geometry[1])
                 let circle = MGLCircleStyleAnnotation(center: coordinate)
-                //TODO: Convert options to circle
+                Convert.interpretCircleOptions(options: arguments["options"], delegate: circle)
                 circleAnnotationController.addStyleAnnotation(circle)
                 result(circle.identifier)
             } else {
@@ -147,7 +147,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             
             for circle in circleAnnotationController.styleAnnotations() {
                 if circle.identifier == circleId {
-                    //TODO: Convert options to circle
+                    Convert.interpretCircleOptions(options: arguments["options"], delegate: circle as! MGLCircleStyleAnnotation)
                     circleAnnotationController.updateStyleAnnotation(circle)
                     break;
                 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -178,7 +178,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                     lineCoordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
                 }
                 let line = MGLLineStyleAnnotation(coordinates: lineCoordinates, count: UInt(lineCoordinates.count))
-                //TODO: Map options to a line.
+                Convert.interpretLineOptions(options: arguments["options"], delegate: line)
                 lineAnnotationController.addStyleAnnotation(line)
                 result(line.identifier)
             } else {
@@ -191,7 +191,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             
             for line in lineAnnotationController.styleAnnotations() {
                 if line.identifier == lineId {
-                    //TODO: Map options to a line.
+                    Convert.interpretLineOptions(options: arguments["options"], delegate: line as! MGLLineStyleAnnotation)
                     lineAnnotationController.updateStyleAnnotation(line)
                     break;
                 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -84,7 +84,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 // Convert geometry to coordinate and create symbol.
                 let coordinate = CLLocationCoordinate2DMake(geometry[0], geometry[1])
                 let symbol = MGLSymbolStyleAnnotation(coordinate: coordinate)
-                //TODO: Convert options to symbol
+                Convert.interpretSymbolOptions(options: arguments["options"], delegate: symbol)
                 symbolAnnotationController.addStyleAnnotation(symbol)
                 result(symbol.identifier)
             } else {
@@ -97,7 +97,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
 
             for symbol in symbolAnnotationController.styleAnnotations(){
                 if symbol.identifier == symbolIdString {
-                    //TODO: Convert options to symbol
+                    Convert.interpretSymbolOptions(options: arguments["options"], delegate: symbol as! MGLSymbolStyleAnnotation)
                     symbolAnnotationController.updateStyleAnnotation(symbol)
                     break;
                 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -251,6 +251,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             channel.invokeMethod("symbol#onTap", arguments: ["symbol" : "\(symbol.identifier)"])
         } else if let circle = styleAnnotation as? MGLCircleStyleAnnotation {
             channel.invokeMethod("circle#onTap", arguments: ["circle" : "\(circle.identifier)"])
+        } else if let line = styleAnnotation as? MGLLineStyleAnnotation {
+            channel.invokeMethod("line#onTap", arguments: ["line" : "\(line.identifier)"])
         }
     }
     

--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -16,6 +16,7 @@ A new Flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Mapbox-iOS-SDK', '~> 5.4.0'
+  s.dependency 'MapboxAnnotationExtension', '~> 0.0.1-beta.1'
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
 end


### PR DESCRIPTION
This PR implements symbols, lines and circles for iOS using the iOS Annotation Extension. All options for symbols, lines and circles have been implemented with the following exceptions:

1. It is currently not possible to update the geometry of a line. An issue has been created [here](https://github.com/mapbox/mapbox-annotation-extension/issues/58) regarding updating an annotations geometry.
2. The `MGLSymbolStyleAnnotation` has a [textTranslation](url) [property](https://docs.mapbox.com/ios/api/annotation-extension/0.0.1-beta.1/Classes/MGLSymbolStyleAnnotation.html#/c:objc(cs)MGLSymbolStyleAnnotation(py)textTranslation) which is not defined in the `SymbolOptions` in Flutter. Also the Android Annotation Extension does not currently support this property.
3. The `MGLSymbolStyleAnnotation` has a `fontNames` [property](https://docs.mapbox.com/ios/api/annotation-extension/0.0.1-beta.1/Classes/MGLSymbolStyleAnnotation.html#/c:objc(cs)MGLSymbolStyleAnnotation(py)fontNames) for setting the Font stack for the symbols text. Fonts are not defined in the `SymbolOptions` in Flutter but are currently supported by the Android Annotation extension. We should open an issue for extending the symbol options to support a custom font stack.

The readme has been updated to show that symbols, lines and circles are now supported in iOS.