### PR TITLE
#104  Add callback when style is ready

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -307,6 +307,8 @@ final class MapboxMapController
       // needs to be placed after SymbolManager#addClickListener,
       // is fixed with 0.6.0 of annotations plugin
       mapboxMap.addOnMapClickListener(MapboxMapController.this);
+
+      methodChannel.invokeMethod("map#onStyleLoaded", null);
     }
   };
 

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -118,6 +118,20 @@ class LineBodyState extends State<LineBody> {
     );
   }
 
+  void onStyleLoadedCallback() {
+    controller.addLine(
+      LineOptions(
+        geometry: [
+          LatLng(37.4220, -122.0841),
+          LatLng(37.4240, -122.0941)
+        ],
+        lineColor: "#ff0000",
+        lineWidth: 14.0,
+        lineOpacity: 0.5,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -130,6 +144,7 @@ class LineBodyState extends State<LineBody> {
             height: 200.0,
             child: MapboxMap(
               onMapCreated: _onMapCreated,
+              onStyleLoadedCallback: onStyleLoadedCallback,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),
                 zoom: 11.0,

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -137,6 +137,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
         
         mapReadyResult?(nil)
+        channel.invokeMethod("map#onStyleLoaded", arguments: nil)
     }
     
     func mapView(_ mapView: MGLMapView, shouldChangeFrom oldCamera: MGLMapCamera, to newCamera: MGLMapCamera) -> Bool {

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -10,6 +10,7 @@ class MapboxMap extends StatefulWidget {
   const MapboxMap({
     @required this.initialCameraPosition,
     this.onMapCreated,
+    this.onStyleLoadedCallback,
     this.gestureRecognizers,
     this.compassEnabled = true,
     this.cameraTargetBounds = CameraTargetBounds.unbounded,
@@ -31,6 +32,7 @@ class MapboxMap extends StatefulWidget {
   }) : assert(initialCameraPosition != null);
 
   final MapCreatedCallback onMapCreated;
+  final OnStyleLoadedCallback onStyleLoadedCallback;
 
   /// The initial position of the map's camera.
   final CameraPosition initialCameraPosition;
@@ -185,6 +187,7 @@ class _MapboxMapState extends State<MapboxMap> {
   Future<void> onPlatformViewCreated(int id) async {
     final MapboxMapController controller = await MapboxMapController.init(
         id, widget.initialCameraPosition,
+        onStyleLoadedCallback: widget.onStyleLoadedCallback,
         onMapClick: widget.onMapClick,
         onCameraTrackingDismissed: widget.onCameraTrackingDismissed,
         onCameraTrackingChanged: widget.onCameraTrackingChanged);


### PR DESCRIPTION
This PR adds support for an `onStyleLoaded` callback for android and ios from issue: #104 . 

Previously the only callback available was for `onMapCreated` but symbol and line managers were not enabled until the style had finished loading. This caused a race condition where if you attempted to add lines/symbols in the `onMapCreated`, you could get a null pointer for the symbol/line manager.

Also added an example of how adding a line could work with the `onStyleLoaded` callback but can back that out if it's not necessary. 