### PR TITLE
Fixed style callback when channel is nullable

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -152,7 +152,9 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
         
         mapReadyResult?(nil)
-        channel.invokeMethod("map#onStyleLoaded", arguments: nil)
+        if let channel = channel {
+            channel.invokeMethod("map#onStyleLoaded", arguments: nil)
+        }
     }
     
     func mapView(_ mapView: MGLMapView, shouldChangeFrom oldCamera: MGLMapCamera, to newCamera: MGLMapCamera) -> Bool {


### PR DESCRIPTION
Channel was changed to nullable which makes ios build fail if the channel is not verified not null or force unwrapped.