### PR TITLE
Invoke all `camera#` channel methods from iOS MGLMapViewDelegate

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -415,7 +415,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
     }
     
-    func mapViewDidBecomeIdle(_ mapView: MGLMapView) {
+    func mapView(_ mapView: MGLMapView, regionDidChangeAnimated animated: Bool) {
         if let channel = channel {
             channel.invokeMethod("camera#onIdle", arguments: []);
         }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -400,7 +400,21 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
     }
     
-
+    func mapView(_ mapView: MGLMapView, regionWillChangeAnimated animated: Bool) {
+        channel?.invokeMethod("camera#onMoveStarted", arguments: []);
+    }
+    
+    func mapViewRegionIsChanging(_ mapView: MGLMapView) {
+        if !trackCameraPosition { return };
+        channel?.invokeMethod("camera#onMove", arguments: [
+            "position": getCamera()?.toDict(mapView: mapView)
+        ]);
+    }
+    
+    func mapViewDidBecomeIdle(_ mapView: MGLMapView) {
+        channel?.invokeMethod("camera#onIdle", arguments: []);
+    }
+    
     /*
      *  MapboxMapOptionsSink
      */

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -401,18 +401,24 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     }
     
     func mapView(_ mapView: MGLMapView, regionWillChangeAnimated animated: Bool) {
-        channel?.invokeMethod("camera#onMoveStarted", arguments: []);
+        if let channel = channel {
+            channel.invokeMethod("camera#onMoveStarted", arguments: []);
+        }
     }
     
     func mapViewRegionIsChanging(_ mapView: MGLMapView) {
         if !trackCameraPosition { return };
-        channel?.invokeMethod("camera#onMove", arguments: [
-            "position": getCamera()?.toDict(mapView: mapView)
-        ]);
+        if let channel = channel {
+            channel.invokeMethod("camera#onMove", arguments: [
+                "position": getCamera()?.toDict(mapView: mapView)
+            ]);
+        }
     }
     
     func mapViewDidBecomeIdle(_ mapView: MGLMapView) {
-        channel?.invokeMethod("camera#onIdle", arguments: []);
+        if let channel = channel {
+            channel.invokeMethod("camera#onIdle", arguments: []);
+        }
     }
     
     /*


### PR DESCRIPTION
The iOS `MapboxMapController` does not invoke the channel methods
`camera#onMoveStarted`, `camera#onMove`, or `camera#onIdle`, and so
`MapboxMapController` can not notify its listeners when the map
position is moved interactively on iOS.

This changeset implements the appropriate delegate functions of the
`MGLMapViewDelegate` protocol to invoke these channel methods with the
expected arguments.

Note: the Android `MapboxMapController` provides an `isGesture` argument
to `onMoveStarted` and a `map` argument to `onIdle`, but neither of the
arguments are read when the method is handled in the Flutter
implementation of `MapboxMapController`. This iOS implementation only
provides the argument that is read on the Flutter side: the `position`
argument to `onMove`.