### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -7,8 +7,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image:  google/dart:latest
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,0 +1,23 @@
+name: Flutter CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image:  google/dart:latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '12.x'
+    - uses: subosito/flutter-action@v1
+      with:
+        flutter-version: '1.9.1+hotfix.6'
+    - run: flutter pub get
+    - run: flutter test
+    - run: flutter build apk

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,6 +1,6 @@
 name: Flutter CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        ref: 'formatting'
     - uses: actions/setup-java@v1
       with:
         java-version: '12.x'

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -14,8 +14,10 @@ jobs:
       with:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
-      with:
-        flutter-version: '1.9.1+hotfix.6'
+      #with:
+        #flutter-version: '1.9.1+hotfix.6'
     - run: flutter pub get
-    - run: flutter test
-    - run: flutter build apk
+    - name: Lint analysis
+      run: flutter analyze
+    - name: Build APK
+      run: flutter build apk

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        ref: 'formatting'
     - uses: actions/setup-java@v1
       with:
         java-version: '12.x'

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -3,9 +3,8 @@ name: Flutter CI
 on: [push]
 
 jobs:
-  build:
-    name: "Lint analysis and build example APK"
-
+  lint:
+    name: "Static code analysis"
     runs-on: ubuntu-latest
 
 
@@ -18,6 +17,37 @@ jobs:
     - run: flutter pub get
     - name: Lint analysis
       run: flutter analyze
+
+  build-android:
+    name: "Build Android apk"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '12.x'
+    - uses: subosito/flutter-action@v1
+    - run: flutter pub get
+
     - name: Build example APK
       run: cd example && flutter build apk
       # We might want to add a flutter test step in the future, when there actually are tests for this plugin
+        
+  build-iOS:
+    name: Build iOS package
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+      - name: Upgrade flutter
+        run: |
+          flutter channel master
+          flutter upgrade
+      - name: build iOS package
+        run: |
+          cd ./example
+          flutter build ios --release --no-codesign

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -21,5 +21,5 @@ jobs:
     - run: flutter pub get
     - name: Lint analysis
       run: flutter analyze
-    - name: Build APK
-      run: flutter build apk
+    - name: Build example APK
+      run: cd example && flutter build apk

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,6 +1,6 @@
 name: Flutter CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    name: "Lint analysis and build example APK"
 
     runs-on: ubuntu-latest
 
@@ -16,10 +17,9 @@ jobs:
       with:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
-      #with:
-        #flutter-version: '1.9.1+hotfix.6'
     - run: flutter pub get
     - name: Lint analysis
       run: flutter analyze
     - name: Build example APK
       run: cd example && flutter build apk
+      # We might want to add a flutter test step in the future, when there actually are tests for this plugin


### PR DESCRIPTION
I have used Github Actions to implement a simple CI. For every PR, this runs `flutter analyze` for static code analysis and builds the example project for Android and iOS. 

**Note**: this should only be merged after #171 has landed, because the analysis step will otherwise fail due to the still existing hints.

@tobrun Is this what you suggested over at #24 ?