### PR TITLE
Fix missing location indicator on iOS

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -317,7 +317,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     // This is required in order to hide the default Maps SDK pin
     func mapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
         if annotation is MGLUserLocation {
-            return MGLUserLocationAnnotationView()
+            return nil
         }
         return MGLAnnotationView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
     }


### PR DESCRIPTION
As noted in issue #138, the default user location indicator is not
appearing in accordance with the `myLocationRenderMode` setting.
Instead, no indication of the user location appears when that location
is within the displayed map.

This is the relevant API documentation for the method used to override
annotation views:

> The user location annotation view can also be customized via this
> method. When annotation is an instance of `MGLUserLocation` (or equal
> to the map view’s `userLocation` property), return an instance of
> `MGLUserLocationAnnotationView` (or a subclass thereof).

https://docs.mapbox.com/ios/api/maps/5.6.1/Protocols/MGLMapViewDelegate.html#/Managing%20Annotation%20Views

From that it sounds like this controller behaves correctly by returning
"an instance" of `MGLUserLocation`, but perhaps the assumption is that
this instance will provide a specialized implementation. I wasn't able
to find any more information on this.

However, the return value for this function is optional. I found that
returning `nil` when a MGLUserLocation is requested resulted in the
location displaying with a dot as expected.

Note: `MyLocationRenderMode.COMPASS` is not supported, and as far as I
can tell it is not implemented within the Mapbox iOS SDK. Only a blue
dot with no direction arrow is provided. Other render modes may require
a custom iOS implementation in flutter-mapbox-gl.