### PR TITLE
WIP: Line manager creation #161

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -114,6 +114,16 @@ class Convert {
     return ((Number) o).floatValue();
   }
 
+  private static Float[] toFloatArray(Object o) {
+    double[] objectArray = (double[]) o;
+    Float[] floatArray = new Float[objectArray.length];
+    for (int i = 0 ; i < objectArray.length; i++)
+    {
+      floatArray[i] = (float) objectArray[i];
+    }
+    return floatArray;
+  }
+
   private static Float toFloatWrapper(Object o) {
     return (o == null) ? null : toFloat(o);
   }
@@ -417,6 +427,34 @@ class Convert {
     final Object draggable = data.get("draggable");
     if (draggable != null) {
       sink.setDraggable(toBoolean(draggable));
+    }
+  }
+
+  static void interpretLineManagerOptions(Object o, LineManagerOptionsSink sink) {
+    final Map<?, ?> data = toMap(o);
+    final Object lineCap = data.get("lineCap");
+    if (lineCap != null) {
+      sink.setLineCap(toString(lineCap));
+    }
+    final Object lineMiterLimit = data.get("lineMiterLimit");
+    if (lineMiterLimit != null) {
+      sink.setLineMiterLimit(toFloat(lineMiterLimit));
+    }
+    final Object lineRoundLimit = data.get("lineRoundLimit");
+    if (lineRoundLimit != null) {
+      sink.setLineRoundLimit(toFloat(lineRoundLimit));
+    }
+    final Object lineTranslate = data.get("lineTranslate");
+    if (lineTranslate != null) {
+      sink.setLineTranslate(toFloatArray(lineTranslate));
+    }
+    final Object lineTranslateAnchor = data.get("lineTranslateAnchor");
+    if (lineTranslateAnchor != null) {
+      sink.setLineTranslateAnchor(toString(lineTranslateAnchor));
+    }
+    final Object lineDashArray = data.get("lineDashArray");
+    if (lineDashArray != null) {
+      sink.setLineDashArray(toFloatArray(lineDashArray));
     }
   }
 

--- a/android/src/main/java/com/mapbox/mapboxgl/LineController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineController.java
@@ -21,11 +21,13 @@ import com.mapbox.mapboxsdk.utils.ColorUtils;
  * Controller of a single Line on the map.
  */
 class LineController implements LineOptionsSink {
+  private final LineManager lineManager;
   private final Line line;
   private final OnLineTappedListener onTappedListener;
   private boolean consumeTapEvents;
 
-  LineController(Line line, boolean consumeTapEvents, OnLineTappedListener onTappedListener) {
+  LineController(LineManager lineManager, Line line, boolean consumeTapEvents, OnLineTappedListener onTappedListener) {
+    this.lineManager = lineManager;
     this.line = line;
     this.consumeTapEvents = consumeTapEvents;
     this.onTappedListener = onTappedListener;
@@ -38,7 +40,7 @@ class LineController implements LineOptionsSink {
     return consumeTapEvents;
   }
 
-  void remove(LineManager lineManager) {
+  void remove() {
     lineManager.delete(line);
   }
 
@@ -92,7 +94,7 @@ class LineController implements LineOptionsSink {
     line.setDraggable(draggable);
   }
 
-  public void update(LineManager lineManager) {
+  public void update() {
     lineManager.update(line);
   }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/LineManagerBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineManagerBuilder.java
@@ -1,0 +1,48 @@
+package com.mapbox.mapboxgl;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
+
+public class LineManagerBuilder implements LineManagerOptionsSink {
+    private LineManager lineManager;
+
+    LineManagerBuilder(MapView mapView, MapboxMap mapboxMap, Style mapboxStyle) {
+        this.lineManager = new LineManager(mapView, mapboxMap, mapboxStyle);
+    }
+
+    public LineManager build() {
+        return lineManager;
+    }
+
+    @Override
+    public void setLineCap(String lineCap) {
+        lineManager.setLineCap(lineCap);
+    }
+
+    @Override
+    public void setLineMiterLimit(Float lineMiterLimit) {
+        lineManager.setLineMiterLimit(lineMiterLimit);
+    }
+
+    @Override
+    public void setLineRoundLimit(Float lineRoundLimit) {
+        lineManager.setLineRoundLimit(lineRoundLimit);
+    }
+
+    @Override
+    public void setLineTranslate(Float[] lineTranslate) {
+        lineManager.setLineTranslate(lineTranslate);
+    }
+
+    @Override
+    public void setLineTranslateAnchor(String lineTranslateAnchor) {
+        lineManager.setLineTranslateAnchor(lineTranslateAnchor);
+    }
+
+    @Override
+    public void setLineDashArray(Float[] lineDashArray) {
+        lineManager.setLineDasharray(lineDashArray);
+    }
+}

--- a/android/src/main/java/com/mapbox/mapboxgl/LineManagerOptionsSink.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineManagerOptionsSink.java
@@ -1,0 +1,16 @@
+package com.mapbox.mapboxgl;
+
+public interface LineManagerOptionsSink {
+
+    void setLineCap(String lineCap);
+
+    void setLineMiterLimit(Float lineMiterLimit);
+
+    void setLineRoundLimit(Float lineRoundLimit);
+
+    void setLineTranslate(Float[] lineTranslate);
+
+    void setLineTranslateAnchor(String lineTranslateAnchor);
+
+    void setLineDashArray(Float[] lineDashArray);
+}

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -45,6 +45,7 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
+import com.mapbox.mapboxsdk.offline.OfflineManager;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Annotation;
 import com.mapbox.mapboxsdk.plugins.annotation.Circle;
@@ -440,6 +441,22 @@ final class MapboxMapController
         }
         reply.put("features", featuresJson);
         result.success(reply);
+        break;
+      }
+      case "map#invalidateAmbientCache": {
+        OfflineManager fileSource = OfflineManager.getInstance(context);
+
+        fileSource.invalidateAmbientCache(new OfflineManager.FileSourceCallback() {
+          @Override
+          public void onSuccess() {
+            result.success(null);
+          }
+
+          @Override
+          public void onError(@NonNull String message) {
+            result.error("MAPBOX CACHE ERROR", message, null);
+          }
+        });
         break;
       }
       case "symbol#add": {

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -99,6 +99,7 @@ final class MapboxMapController
   private final PluginRegistry.Registrar registrar;
   private final MapView mapView;
   private MapboxMap mapboxMap;
+  private Style mapStyle;
   private final Map<String, SymbolController> symbols;
   private final Map<String, LineController> lines;
   private final Map<String, CircleController> circles;
@@ -312,9 +313,12 @@ final class MapboxMapController
   Style.OnStyleLoaded onStyleLoadedCallback = new Style.OnStyleLoaded() {
     @Override
     public void onStyleLoaded(@NonNull Style style) {
+      MapboxMapController.this.mapStyle = style;
+
       enableLineManager(style);
       enableSymbolManager(style);
       enableCircleManager(style);
+
       if (myLocationEnabled) {
         enableLocationComponent(style);
       }
@@ -479,6 +483,17 @@ final class MapboxMapController
         final SymbolController symbol = symbol(symbolId);
         Convert.interpretSymbolOptions(call.argument("options"), symbol);
         symbol.update(symbolManager);
+        result.success(null);
+        break;
+      }
+      case "lineManager#set": {
+        final LineManagerBuilder lineManagerBuilder = new LineManagerBuilder(mapView, mapboxMap, mapStyle);
+        Convert.interpretLineManagerOptions(call.argument("options"), lineManagerBuilder);
+        final LineManager lineManager = lineManagerBuilder.build();
+        if (this.lineManager != null) {
+          this.lineManager.onDestroy();
+        }
+        this.lineManager = lineManager;
         result.success(null);
         break;
       }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -59,6 +59,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             } else {
                 result(nil)
             }
+        case "map#invalidateAmbientCache":
+            MGLOfflineStorage.shared.invalidateAmbientCache{
+                (error) in
+                if let error = error {
+                    result(error)
+                } else{
+                    result(nil)
+                }
+            }
         case "map#updateMyLocationTrackingMode":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             if let myLocationTrackingMode = arguments["mode"] as? UInt, let trackingMode = MGLUserTrackingMode(rawValue: myLocationTrackingMode) {

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -6,6 +6,7 @@ library mapbox_gl;
 
 import 'dart:async';
 import 'dart:math';
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -441,10 +441,12 @@ class MapboxMapController extends ChangeNotifier {
   Future<LatLng> getCircleLatLng(Circle circle) async {
     assert(circle != null);
     assert(_circles[circle._id] == circle);
-    Map mapLatLng = await _channel.invokeMethod('circle#getGeometry', <String, dynamic>{
+    Map mapLatLng =
+        await _channel.invokeMethod('circle#getGeometry', <String, dynamic>{
       'circle': circle._id,
     });
-    LatLng circleLatLng = new LatLng(mapLatLng['latitude'], mapLatLng['longitude']);
+    LatLng circleLatLng =
+        new LatLng(mapLatLng['latitude'], mapLatLng['longitude']);
     notifyListeners();
     return circleLatLng;
   }
@@ -524,6 +526,16 @@ class MapboxMapController extends ChangeNotifier {
       );
       return reply['features'];
     } on PlatformException catch (e) {
+      return new Future.error(e);
+    }
+  }
+
+
+  Future invalidateAmbientCache() async {
+    try {
+      await _channel.invokeMethod('map#invalidateAmbientCache');
+      return null;
+      } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -208,6 +208,13 @@ class MapboxMapController extends ChangeNotifier {
     });
   }
 
+  ///
+  Future<void> updateLineManager(LineManagerOptions lineManagerOptions) async {
+    await _channel.invokeMethod('lineManager#set', <String, dynamic>{
+      'options': lineManagerOptions._toJson(),
+    });
+  }
+
   /// Changes the map camera position.
   ///
   /// The returned [Future] completes after the change has been made on the

--- a/lib/src/line.dart
+++ b/lib/src/line.dart
@@ -102,3 +102,47 @@ class LineOptions {
     return json;
   }
 }
+
+/// Configuration options for [LineManager] instances.
+///
+/// When used to change configuration, null values will be interpreted as
+/// "do not change this configuration option".
+class LineManagerOptions {
+  /// Creates a set of line manager configuration options.
+  ///
+  /// By default, every non-specified field is null, meaning no desire to change
+  /// line defaults or current configuration.
+  const LineManagerOptions({
+    this.lineCap,
+    this.lineMiterLimit,
+    this.lineRoundLimit,
+    this.lineTranslate,
+    this.lineTranslateAnchor,
+    this.lineDashArray,
+  });
+
+  final String lineCap;
+  final double lineMiterLimit;
+  final double lineRoundLimit;
+  final Float64List lineTranslate;
+  final String lineTranslateAnchor;
+  final Float64List lineDashArray;
+
+  dynamic _toJson() {
+    final Map<String, dynamic> json = <String, dynamic>{};
+
+    void addIfPresent(String fieldName, dynamic value) {
+      if (value != null) {
+        json[fieldName] = value;
+      }
+    }
+
+    addIfPresent('lineCap', lineCap);
+    addIfPresent('lineMiterLimit', lineMiterLimit);
+    addIfPresent('lineRoundLimit', lineRoundLimit);
+    addIfPresent('lineTranslate', lineTranslate);
+    addIfPresent('lineTranslateAnchor', lineTranslateAnchor);
+    addIfPresent('lineDashArray', lineDashArray);
+    return json;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,5 @@ dependencies:
     sdk: flutter
 flutter:
   plugin:
-    platforms:
-      android:
-        package: com.mapbox.mapboxgl
-        pluginClass: MapboxMapsPlugin
-      ios:
-        pluginClass: MapboxMapsPlugin
+    androidPackage: com.mapbox.mapboxgl
+    pluginClass: MapboxMapsPlugin


### PR DESCRIPTION
This is the initial take on the ability to add line managers and subsequently add lines to a specific manager. The would allow us to add specific manager only styling to groups of annotations rather than just the defaults.

The implementation is basically creating a new line manager with configuration options and storing it in a map using a random uuid as the key and returning that uuid through the method channel. That uuid can then be used in the future to add lines to that specific manager.

Open to all comments/questions, if all looks good I'm happy to add this to ios and for symbols/circles too!