### PR TITLE
Fix MapboxMapsPlugin Nullpointer

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
@@ -30,6 +30,11 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
   private final int registrarActivityHashCode;
 
   public static void registerWith(Registrar registrar) {
+    if (registrar.activity() == null) {
+      // When a background flutter view tries to register the plugin, the registrar has no activity.
+      // We stop the registration process as this plugin is foreground only.
+      return;
+    }
     final MapboxMapsPlugin plugin = new MapboxMapsPlugin(registrar);
     registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
     registrar

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
@@ -27,7 +27,7 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
   static final int STOPPED = 5;
   static final int DESTROYED = 6;
   private final AtomicInteger state = new AtomicInteger(0);
-  private final int registrarActivityHashCode;
+  private Integer registrarActivityHashCode = null;
 
   public static void registerWith(Registrar registrar) {
     final MapboxMapsPlugin plugin = new MapboxMapsPlugin(registrar);
@@ -44,6 +44,9 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
 
   @Override
   public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+    if(registrarActivityHashCode == null) {
+      registrarActivityHashCode = activity.hashCode();
+    }
     if (activity.hashCode() != registrarActivityHashCode) {
       return;
     }
@@ -95,6 +98,8 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
   }
 
   private MapboxMapsPlugin(Registrar registrar) {
-    this.registrarActivityHashCode = registrar.activity().hashCode();
+    if(registrar.activity() != null) {
+      this.registrarActivityHashCode = registrar.activity().hashCode();
+    }
   }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
@@ -27,7 +27,7 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
   static final int STOPPED = 5;
   static final int DESTROYED = 6;
   private final AtomicInteger state = new AtomicInteger(0);
-  private Integer registrarActivityHashCode = null;
+  private final int registrarActivityHashCode;
 
   public static void registerWith(Registrar registrar) {
     final MapboxMapsPlugin plugin = new MapboxMapsPlugin(registrar);
@@ -44,9 +44,6 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
 
   @Override
   public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-    if(registrarActivityHashCode == null) {
-      registrarActivityHashCode = activity.hashCode();
-    }
     if (activity.hashCode() != registrarActivityHashCode) {
       return;
     }
@@ -98,8 +95,6 @@ public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks 
   }
 
   private MapboxMapsPlugin(Registrar registrar) {
-    if(registrar.activity() != null) {
-      this.registrarActivityHashCode = registrar.activity().hashCode();
-    }
+    this.registrarActivityHashCode = registrar.activity().hashCode();
   }
 }


### PR DESCRIPTION
Potential fix for this issue: https://github.com/tobrun/flutter-mapbox-gl/issues/141

~When the app is initialized in the background the activity provided by the Registrar can be null,
causing the app to crash. This commit checks if the activity is null before resolving its hashCode. If it is null the initialization of this.registrarActivityHashCode is delayed until onActivityCreated is called.~

Initial approach was invalid, now applied the same approach as the [GoogleMapsPlugin](https://github.com/flutter/plugins/blob/master/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java) which seems to fix the issue :)