### PR TITLE
[example] remove invalid access token

### DIFF
--- a/example/android/app/src/main/res/values/developer-config.xml
+++ b/example/android/app/src/main/res/values/developer-config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="mapbox_access_token">pk.eyJ1IjoibnVyYm90IiwiYSI6ImNpaG0ycXA3czBvamh2NWtsZzBzdHE2dmQifQ.B7NiVcQD0DFguQF1aRcOeQ</string>
+    <string name="mapbox_access_token">ADD_MAPBOX_ACCESS_TOKEN_HERE</string>
 </resources>


### PR DESCRIPTION
This token wasn't supposed to be committed and has been removed/invalidated.  