### PR TITLE
Add icon/text allow overlap configuration

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -369,6 +369,8 @@ final class MapboxMapController
     }
   }
 
+
+
   private void enableLineManager(@NonNull Style style) {
     if (lineManager == null) {
       lineManager = new LineManager(mapView, mapboxMap, style);
@@ -558,6 +560,30 @@ final class MapboxMapController
         final SymbolController symbol = symbol(symbolId);
         Convert.interpretSymbolOptions(call.argument("options"), symbol);
         symbol.update(symbolManager);
+        result.success(null);
+        break;
+      }
+      case "symbolManager#iconAllowOverlap": {
+        final Boolean value = call.argument("iconAllowOverlap");
+        symbolManager.setIconAllowOverlap(value);
+        result.success(null);
+        break;
+      }
+      case "symbolManager#iconIgnorePlacement": {
+        final Boolean value = call.argument("iconIgnorePlacement");
+        symbolManager.setIconIgnorePlacement(value);
+        result.success(null);
+        break;
+      }
+      case "symbolManager#textAllowOverlap": {
+        final Boolean value = call.argument("textAllowOverlap");
+        symbolManager.setTextAllowOverlap(value);
+        result.success(null);
+        break;
+      }
+      case "symbolManager#textIgnorePlacement": {
+        final Boolean iconAllowOverlap = call.argument("textIgnorePlacement");
+        symbolManager.setTextIgnorePlacement(iconAllowOverlap);
         result.success(null);
         break;
       }

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -261,7 +261,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                         ),
                         FlatButton(
                           child:  Text('${_iconAllowOverlap ? 'disable' : 'enable'} icon overlap'),
-                          onPressed: _changeIconOverlap
+                          onPressed: _changeIconOverlap,
                           child: const Text('add (asset image)'),
                           onPressed: () => (_symbolCount == 12)
                               ? null

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -262,6 +262,8 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                         FlatButton(
                           child:  Text('${_iconAllowOverlap ? 'disable' : 'enable'} icon overlap'),
                           onPressed: _changeIconOverlap,
+                        ),
+                        FlatButton(
                           child: const Text('add (asset image)'),
                           onPressed: () => (_symbolCount == 12)
                               ? null

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -34,6 +34,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   MapboxMapController controller;
   int _symbolCount = 0;
   Symbol _selectedSymbol;
+  bool _iconAllowOverlap = false;
 
   void _onMapCreated(MapboxMapController controller) {
     this.controller = controller;
@@ -185,6 +186,13 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     );
   }
 
+  Future<void> _changeIconOverlap() async {
+    setState(() {
+      _iconAllowOverlap = !_iconAllowOverlap;
+    });
+    controller.setSymbolIconAllowOverlap(_iconAllowOverlap);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -227,6 +235,10 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                         FlatButton(
                           child: const Text('remove'),
                           onPressed: (_selectedSymbol == null) ? null : _remove,
+                        ),
+                        FlatButton(
+                          child:  Text('${_iconAllowOverlap ? 'disable' : 'enable'} icon overlap'),
+                          onPressed: _changeIconOverlap
                         ),
                       ],
                     ),

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -173,6 +173,29 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+        case "symbolManager#iconAllowOverlap":
+            guard let symbolAnnotationController = symbolAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let iconAllowOverlap = arguments["iconAllowOverlap"] as? Bool else { return }
+
+            symbolAnnotationController.iconAllowsOverlap = iconAllowOverlap
+            result(nil)
+        case "symbolManager#iconIgnorePlacement":
+            guard let symbolAnnotationController = symbolAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let iconIgnorePlacement = arguments["iconIgnorePlacement"] as? Bool else { return }
+
+            symbolAnnotationController.iconIgnoresPlacement = iconIgnorePlacement
+            result(nil)
+        case "symbolManager#textAllowOverlap":
+            guard let symbolAnnotationController = symbolAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let textAllowOverlap = arguments["textAllowOverlap"] as? Bool else { return }
+
+            symbolAnnotationController.textAllowsOverlap = textAllowOverlap
+            result(nil)
+        case "symbolManager#textIgnorePlacement":
+            result(FlutterMethodNotImplemented)
         case "circle#add":
             guard let circleAnnotationController = circleAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -354,6 +354,30 @@ class MapboxMapController extends ChangeNotifier {
     _symbols.remove(id);
   }
 
+  Future<void> setSymbolIconAllowOverlap(bool enable) async {
+    await _channel.invokeMethod('symbolManager#iconAllowOverlap', <String, dynamic>{
+      'iconAllowOverlap': enable,
+    });
+  }
+
+  Future<void> setSymbolIconIgnorePlacement(bool enable) async {
+    await _channel.invokeMethod('symbolManager#iconIgnorePlacement', <String, dynamic>{
+      'iconIgnorePlacement': enable,
+    });
+  }
+
+  Future<void> setSymbolTextAllowOverlap(bool enable) async {
+    await _channel.invokeMethod('symbolManager#textAllowOverlap', <String, dynamic>{
+      'textAllowOverlap': enable,
+    });
+  }
+
+  Future<void> setSymbolTextIgnorePlacement(bool enable) async {
+    await _channel.invokeMethod('symbolManager#textIgnorePlacement', <String, dynamic>{
+      'textIgnorePlacement': enable,
+    });
+  }
+
   /// Adds a line to the map, configured using the specified custom [options].
   ///
   /// Change listeners are notified once the line has been added on the

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -392,24 +392,28 @@ class MapboxMapController extends ChangeNotifier {
     _symbols.remove(id);
   }
 
+  /// For more information on what this does, see https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-collision
   Future<void> setSymbolIconAllowOverlap(bool enable) async {
     await _channel.invokeMethod('symbolManager#iconAllowOverlap', <String, dynamic>{
       'iconAllowOverlap': enable,
     });
   }
-
+  
+  /// For more information on what this does, see https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-collision
   Future<void> setSymbolIconIgnorePlacement(bool enable) async {
     await _channel.invokeMethod('symbolManager#iconIgnorePlacement', <String, dynamic>{
       'iconIgnorePlacement': enable,
     });
   }
-
+  
+  /// For more information on what this does, see https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-collision
   Future<void> setSymbolTextAllowOverlap(bool enable) async {
     await _channel.invokeMethod('symbolManager#textAllowOverlap', <String, dynamic>{
       'textAllowOverlap': enable,
     });
   }
 
+  /// For more information on what this does, see https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-collision
   Future<void> setSymbolTextIgnorePlacement(bool enable) async {
     await _channel.invokeMethod('symbolManager#textIgnorePlacement', <String, dynamic>{
       'textIgnorePlacement': enable,


### PR DESCRIPTION
Closes #https://github.com/tobrun/flutter-mapbox-gl/issues/119

This PR adds configuration for enabling/disabling:
 - SymbolManager#iconAllowOverlap
 - SymbolManager#iconIgnorePlacement
 - SymbolManager#textAllowOverlap
 - SymbolManager#textIgnorePlacement

These configurations apply to all symbols maitained by the given manager.

![ezgif com-video-to-gif (9)](https://user-images.githubusercontent.com/2151639/73132544-f57b9380-401c-11ea-8ae3-a259578fd2fb.gif)
