### PR TITLE
Provide `onMapIdle` callback

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -421,6 +421,12 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         }
     }
     
+    func mapViewDidBecomeIdle(_ mapView: MGLMapView) {
+        if let channel = channel {
+            channel.invokeMethod("map#onIdle", arguments: []);
+        }
+    }
+    
     func mapView(_ mapView: MGLMapView, regionWillChangeAnimated animated: Bool) {
         if let channel = channel {
             channel.invokeMethod("camera#onMoveStarted", arguments: []);

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -11,6 +11,8 @@ typedef void OnStyleLoadedCallback();
 typedef void OnCameraTrackingDismissedCallback();
 typedef void OnCameraTrackingChangedCallback(MyLocationTrackingMode mode);
 
+typedef void OnMapIdleCallback();
+
 /// Controller for a single MapboxMap instance running on the host platform.
 ///
 /// Change listeners are notified upon changes to any of
@@ -32,7 +34,8 @@ class MapboxMapController extends ChangeNotifier {
       {this.onStyleLoadedCallback,
       this.onMapClick,
       this.onCameraTrackingDismissed,
-      this.onCameraTrackingChanged})
+      this.onCameraTrackingChanged,
+      this.onMapIdle})
       : assert(_id != null),
         assert(channel != null),
         _channel = channel {
@@ -45,7 +48,8 @@ class MapboxMapController extends ChangeNotifier {
       {OnStyleLoadedCallback onStyleLoadedCallback,
       OnMapClickCallback onMapClick,
       OnCameraTrackingDismissedCallback onCameraTrackingDismissed,
-      OnCameraTrackingChangedCallback onCameraTrackingChanged}) async {
+      OnCameraTrackingChangedCallback onCameraTrackingChanged,
+      OnMapIdleCallback onMapIdle}) async {
     assert(id != null);
     final MethodChannel channel =
         MethodChannel('plugins.flutter.io/mapbox_maps_$id');
@@ -54,7 +58,8 @@ class MapboxMapController extends ChangeNotifier {
         onStyleLoadedCallback: onStyleLoadedCallback,
         onMapClick: onMapClick,
         onCameraTrackingDismissed: onCameraTrackingDismissed,
-        onCameraTrackingChanged: onCameraTrackingChanged);
+        onCameraTrackingChanged: onCameraTrackingChanged,
+        onMapIdle: onMapIdle);
   }
 
   final MethodChannel _channel;
@@ -65,6 +70,8 @@ class MapboxMapController extends ChangeNotifier {
 
   final OnCameraTrackingDismissedCallback onCameraTrackingDismissed;
   final OnCameraTrackingChangedCallback onCameraTrackingChanged;
+
+  final OnMapIdleCallback onMapIdle;
 
   /// Callbacks to receive tap events for symbols placed on this map.
   final ArgumentCallbacks<Symbol> onSymbolTapped = ArgumentCallbacks<Symbol>();
@@ -173,6 +180,11 @@ class MapboxMapController extends ChangeNotifier {
       case 'map#onCameraTrackingDismissed':
         if (onCameraTrackingDismissed != null) {
           onCameraTrackingDismissed();
+        }
+        break;
+      case 'map#onIdle':
+        if (onMapIdle != null) {
+          onMapIdle();
         }
         break;
       default:

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -31,6 +31,7 @@ class MapboxMap extends StatefulWidget {
     this.onMapClick,
     this.onCameraTrackingDismissed,
     this.onCameraTrackingChanged,
+    this.onMapIdle,
   }) : assert(initialCameraPosition != null);
 
   final MapCreatedCallback onMapCreated;
@@ -130,6 +131,14 @@ class MapboxMap extends StatefulWidget {
   final OnCameraTrackingDismissedCallback onCameraTrackingDismissed;
   final OnCameraTrackingChangedCallback onCameraTrackingChanged;
 
+  /// Called when map view is entering an idle state, and no more drawing will
+  /// be necessary until new data is loaded or there is some interaction with
+  /// the map.
+  /// * No camera transitions are in progress
+  /// * All currently requested tiles have loaded
+  /// * All fade/transition animations have completed
+  final OnMapIdleCallback onMapIdle;
+
   @override
   State createState() => _MapboxMapState();
 }
@@ -198,7 +207,8 @@ class _MapboxMapState extends State<MapboxMap> {
         onStyleLoadedCallback: widget.onStyleLoadedCallback,
         onMapClick: widget.onMapClick,
         onCameraTrackingDismissed: widget.onCameraTrackingDismissed,
-        onCameraTrackingChanged: widget.onCameraTrackingChanged);
+        onCameraTrackingChanged: widget.onCameraTrackingChanged,
+        onMapIdle: widget.onMapIdle);
     _controller.complete(controller);
     if (widget.onMapCreated != null) {
       widget.onMapCreated(controller);


### PR DESCRIPTION
Corresponding to `mapViewDidBecomeIdle` in the iOS SDK, this informs the
application "that the map view is entering an idle state, and no more
drawing will be necessary until new data is loaded or there is some
interaction with the map."

https://docs.mapbox.com/ios/api/maps/5.6.1/Protocols/MGLMapViewDelegate.html#/c:objc(pl)MGLMapViewDelegate(im)mapViewDidBecomeIdle:

I have not provided an Android implementation as I am not set up to test
one yet. I would do this later if it's still missing.