### PR TITLE
Support setting map's content insets

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -90,6 +90,21 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 style.localizeLabels(into: nil)
             }
             result(nil)
+        case "map#updateContentInsets":
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+
+            if let bounds = arguments["bounds"] as? [String: Any],
+                let top = bounds["top"] as? CGFloat,
+                let left = bounds["left"]  as? CGFloat,
+                let bottom = bounds["bottom"] as? CGFloat,
+                let right = bounds["right"] as? CGFloat,
+                let animated = arguments["animated"] as? Bool {
+                mapView.setContentInset(UIEdgeInsets(top: top, left: left, bottom: bottom, right: right), animated: animated) {
+                    result(nil)
+                }
+            } else {
+                result(nil)
+            }
         case "map#setMapLanguage":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             if let localIdentifier = arguments["language"] as? String, let style = mapView.style {

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -243,6 +243,30 @@ class MapboxMapController extends ChangeNotifier {
     await _channel.invokeMethod('map#matchMapLanguageWithDeviceDefault');
   }  
   
+  /// Updates the distance from the edges of the map view’s frame to the edges
+  /// of the map view’s logical viewport, optionally animating the change.
+  ///
+  /// When the value of this property is equal to `EdgeInsets.zero`, viewport
+  /// properties such as centerCoordinate assume a viewport that matches the map
+  /// view’s frame. Otherwise, those properties are inset, excluding part of the
+  /// frame from the viewport. For instance, if the only the top edge is inset,
+  /// the map center is effectively shifted downward.
+  ///
+  /// The returned [Future] completes after the change has been made on the
+  /// platform side.
+  Future<void> updateContentInsets(EdgeInsets insets,
+      [bool animated = false]) async {
+    await _channel.invokeMethod('map#updateContentInsets', <String, dynamic>{
+      'bounds': <String, double>{
+        'top': insets.top,
+        'left': insets.left,
+        'bottom': insets.bottom,
+        'right': insets.right,
+      },
+      'animated': animated,
+    });
+  }
+
   /// Updates the language of the map labels to match the specified language.
   /// Supported language strings are available here: https://github.com/mapbox/mapbox-plugins-android/blob/e29c18d25098eb023a831796ff807e30d8207c36/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java#L39-L87
   ///


### PR DESCRIPTION
This allows the maps center (corresponding to a user location, or any
given coordinate) to be automatically offset to account for content that
is inset within the map.

https://docs.mapbox.com/ios/api/maps/5.6.1/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(im)setContentInset:animated:completionHandler: