### PR TITLE
Update README: Access Tokens for self-hosted tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We're compiling a list of apps using this SDK. If you want to be listed here, pl
 #### Mapbox Access Token
 
 This project uses Mapbox vector tiles, which requires a Mapbox account and a Mapbox access token. Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
-> **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) you will need to specify the keys explained below, though you can set the Access Token to any string, including an empty string, in this case!**
+> **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) with this plugin, you will need to specify any non-empty string as Access Token as explained below!**
 
 ##### Android
 Add Mapbox read token value in the application manifest ```android/app/src/main/AndroidManifest.xml:```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We're compiling a list of apps using this SDK. If you want to be listed here, pl
 #### Mapbox Access Token
 
 This project uses Mapbox vector tiles, which requires a Mapbox account and a Mapbox access token. Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
+> **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) you will need to specify the keys explained below, though you can set the Access Token to any string, including an empty string, in this case!**
 
 ##### Android
 Add Mapbox read token value in the application manifest ```android/app/src/main/AndroidManifest.xml:```


### PR DESCRIPTION
As noted in #142, we currently throw an error if the access token is missing or empty, even if the user doesn't use Mapbox tiles. This is now documented.
We might want to consider changing this behavior to allow empty tokens in the future.