### PR TITLE
Support "Compass" location render mode

### DIFF
--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -37,6 +37,9 @@ class Convert {
         if let myLocationTrackingMode = options["myLocationTrackingMode"] as? UInt, let trackingMode = MGLUserTrackingMode(rawValue: myLocationTrackingMode) {
             delegate.setMyLocationTrackingMode(myLocationTrackingMode: trackingMode)
         }
+        if let myLocationRenderMode = options["myLocationRenderMode"] as? Int, let renderMode = MyLocationRenderMode(rawValue: myLocationRenderMode) {
+            delegate.setMyLocationRenderMode(myLocationRenderMode: renderMode)
+        }
         if let logoViewMargins = options["logoViewMargins"] as? [Double] {
             delegate.setLogoViewMargins(x: logoViewMargins[0], y: logoViewMargins[1])
         }

--- a/ios/Classes/Enums.swift
+++ b/ios/Classes/Enums.swift
@@ -1,0 +1,3 @@
+enum MyLocationRenderMode: Int {
+    case Normal, Compass, Gps
+}

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -522,6 +522,16 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     func setMyLocationTrackingMode(myLocationTrackingMode: MGLUserTrackingMode) {
         mapView.userTrackingMode = myLocationTrackingMode
     }
+    func setMyLocationRenderMode(myLocationRenderMode: MyLocationRenderMode) {
+        switch myLocationRenderMode {
+        case .Normal:
+            mapView.showsUserHeadingIndicator = false
+        case .Compass:
+            mapView.showsUserHeadingIndicator = true
+        case .Gps:
+            NSLog("RenderMode.GPS currently not supported")
+        }
+    }
     func setLogoViewMargins(x: Double, y: Double) {
         mapView.logoViewMargins = CGPoint(x: x, y: y)
     }

--- a/ios/Classes/MapboxMapOptionsSink.swift
+++ b/ios/Classes/MapboxMapOptionsSink.swift
@@ -13,6 +13,7 @@ protocol MapboxMapOptionsSink {
     func setZoomGesturesEnabled(zoomGesturesEnabled: Bool)
     func setMyLocationEnabled(myLocationEnabled: Bool)
     func setMyLocationTrackingMode(myLocationTrackingMode: MGLUserTrackingMode)
+    func setMyLocationRenderMode(myLocationRenderMode: MyLocationRenderMode)
     func setLogoViewMargins(x: Double, y: Double)
     func setCompassViewPosition(position: MGLOrnamentPosition)
     func setCompassViewMargins(x: Double, y: Double)


### PR DESCRIPTION
Adds support to `Convert` for the "myLocationRenderMode" option, reading
the option supplied. The `MapboxMapController` receives this option and
configures the map for `Normal` or `Compass` when these are supplied. A
"GPS" render mode is not provided by the SDK, so a message is logged
when it is provided.