### PR TITLE
Fix CI errors

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,7 @@ class MapsDemo extends StatelessWidget {
   void _pushPage(BuildContext context, Page page) async {
     final location = Location();
     final hasPermissions = await location.hasPermission();
-    if (!hasPermissions) {
+    if (hasPermissions != PermissionStatus.GRANTED) {
       await location.requestPermission();
     }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  location: ^2.3.5
+  location: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
It seems that the CI is installing version 2.5.3 of the location package as opposed to version 2.3.5 which is specified in the pubspec.yaml. As of 2.5.0 there is a breaking change in the `hasPermission` method, it now returns an enum instead of a bool. 

Also see: https://pub.dev/packages/location#-changelog-tab-