### PR TITLE
Rename Page widget to ExamplePage in the example

### DIFF
--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -7,7 +7,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class AnimateCameraPage extends Page {
+class AnimateCameraPage extends ExamplePage {
   AnimateCameraPage()
       : super(const Icon(Icons.map), 'Camera control, animated');
 

--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -3,7 +3,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class FullMapPage extends Page {
+class FullMapPage extends ExamplePage {
   FullMapPage()
       : super(const Icon(Icons.map), 'Full screen map');
 

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -9,7 +9,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class LinePage extends Page {
+class LinePage extends ExamplePage {
   LinePage() : super(const Icon(Icons.share), 'Line');
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ import 'place_circle.dart';
 import 'place_symbol.dart';
 import 'scrolling_map.dart';
 
-final List<Page> _allPages = <Page>[
+final List<ExamplePage> _allPages = <ExamplePage>[
   MapUiPage(),
   FullMapPage(),
   AnimateCameraPage(),
@@ -28,7 +28,7 @@ final List<Page> _allPages = <Page>[
 ];
 
 class MapsDemo extends StatelessWidget {
-  void _pushPage(BuildContext context, Page page) async {
+  void _pushPage(BuildContext context, ExamplePage page) async {
     final location = Location();
     final hasPermissions = await location.hasPermission();
     if (hasPermissions != PermissionStatus.GRANTED) {

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -12,7 +12,7 @@ final LatLngBounds sydneyBounds = LatLngBounds(
   northeast: const LatLng(-33.571835, 151.325952),
 );
 
-class MapUiPage extends Page {
+class MapUiPage extends ExamplePage {
   MapUiPage() : super(const Icon(Icons.map), 'User interface');
 
   @override

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -7,7 +7,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class MoveCameraPage extends Page {
+class MoveCameraPage extends ExamplePage {
   MoveCameraPage() : super(const Icon(Icons.map), 'Camera control');
 
   @override

--- a/example/lib/page.dart
+++ b/example/lib/page.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 
-abstract class Page extends StatelessWidget {
-  const Page(this.leading, this.title);
+abstract class ExamplePage extends StatelessWidget {
+  const ExamplePage(this.leading, this.title);
 
   final Widget leading;
   final String title;

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -10,7 +10,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class PlaceCirclePage extends Page {
+class PlaceCirclePage extends ExamplePage {
   PlaceCirclePage() : super(const Icon(Icons.check_circle), 'Place circle');
 
   @override

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -10,7 +10,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class PlaceSymbolPage extends Page {
+class PlaceSymbolPage extends ExamplePage {
   PlaceSymbolPage() : super(const Icon(Icons.place), 'Place symbol');
 
   @override

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -10,7 +10,7 @@ import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
 
-class ScrollingMapPage extends Page {
+class ScrollingMapPage extends ExamplePage {
   ScrollingMapPage() : super(const Icon(Icons.map), 'Scrolling map');
 
   @override


### PR DESCRIPTION
This resolves the CI error where the Page widget is defined twice, because Flutter recently also added their own Page widget (as @andrea689 noticed).