### PR TITLE
Implement addImage() to style

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -654,7 +654,8 @@ final class MapboxMapController
         if(style==null){
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
         }
-        style.addImage(call.argument("name"), BitmapFactory.decodeByteArray(call.argument("bytes"),0,call.argument("length")));
+        style.addImage(call.argument("name"), BitmapFactory.decodeByteArray(call.argument("bytes"),0,call.argument("length")), call.argument("sdf"));
+        result.success(null);
         break;
       }
       default:

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -124,6 +124,7 @@ final class MapboxMapController
   private LocationComponent locationComponent = null;
   private LocationEngine locationEngine = null;
   private LocalizationPlugin localizationPlugin;
+  private Style style;
 
   MapboxMapController(
     int id,
@@ -319,6 +320,7 @@ final class MapboxMapController
   Style.OnStyleLoaded onStyleLoadedCallback = new Style.OnStyleLoaded() {
     @Override
     public void onStyleLoaded(@NonNull Style style) {
+      MapboxMapController.this.style = style;
       enableLineManager(style);
       enableSymbolManager(style);
       enableCircleManager(style);
@@ -646,6 +648,13 @@ final class MapboxMapController
             }
           });
         }
+        break;
+      }
+      case "style#addImage":{
+        if(style==null){
+          result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
+        }
+        style.addImage(call.argument("name"), BitmapFactory.decodeByteArray(call.argument("bytes"),0,call.argument("length")));
         break;
       }
       default:

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -4,8 +4,11 @@
 
 import 'dart:async';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
 import 'page.dart';
@@ -185,6 +188,19 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     );
   }
 
+  /// Adds an asset image to the currently displayed style
+  Future<void> addImageFromAsset(String name, String assetName) async {
+    final ByteData bytes = await rootBundle.load(assetName);
+    final Uint8List list = bytes.buffer.asUint8List();
+    return controller.addImage(name, list);
+  }
+
+  /// Adds a network image to the currently displayed style
+  Future<void> addImageFromUrl(String name, String url) async {
+    var response = await get(url);
+    return controller.addImage(name, response.bodyBytes);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -228,6 +244,22 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                           child: const Text('remove'),
                           onPressed: (_selectedSymbol == null) ? null : _remove,
                         ),
+                        FlatButton(
+                          child: const Text('add (asset image)'),
+                          onPressed: () => (_symbolCount == 12)
+                              ? null
+                              : addImageFromAsset(
+                                      "testAsset", "assets/symbols/custom-icon.png")
+                                  .then((_) => _add("testAsset")),
+                        ),
+                        FlatButton(
+                          child: const Text('add (network image)'),
+                          onPressed: () => (_symbolCount == 12)
+                              ? null
+                              : addImageFromUrl(
+                                      "testNetwork", "https://via.placeholder.com/30")
+                                  .then((_) => _add("testNetwork")),
+                        ),
                       ],
                     ),
                     Column(
@@ -239,8 +271,9 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                         ),
                         FlatButton(
                           child: const Text('change icon offset'),
-                          onPressed:
-                              (_selectedSymbol == null) ? null : _changeIconOffset,
+                          onPressed: (_selectedSymbol == null)
+                              ? null
+                              : _changeIconOffset,
                         ),
                         FlatButton(
                           child: const Text('change icon anchor'),

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -43,10 +43,28 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     controller.onSymbolTapped.add(_onSymbolTapped);
   }
 
+  void _onStyleLoaded() {
+    addImageFromAsset("assetImage", "assets/symbols/custom-icon.png");
+    addImageFromUrl("networkImage", "https://via.placeholder.com/50");
+  }
+
   @override
   void dispose() {
     controller?.onSymbolTapped?.remove(_onSymbolTapped);
     super.dispose();
+  }
+
+  /// Adds an asset image to the currently displayed style
+  Future<void> addImageFromAsset(String name, String assetName) async {
+    final ByteData bytes = await rootBundle.load(assetName);
+    final Uint8List list = bytes.buffer.asUint8List();
+    return controller.addImage(name, list);
+  }
+
+  /// Adds a network image to the currently displayed style
+  Future<void> addImageFromUrl(String name, String url) async {
+    var response = await get(url);
+    return controller.addImage(name, response.bodyBytes);
   }
 
   void _onSymbolTapped(Symbol symbol) {
@@ -188,18 +206,6 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     );
   }
 
-  /// Adds an asset image to the currently displayed style
-  Future<void> addImageFromAsset(String name, String assetName) async {
-    final ByteData bytes = await rootBundle.load(assetName);
-    final Uint8List list = bytes.buffer.asUint8List();
-    return controller.addImage(name, list);
-  }
-
-  /// Adds a network image to the currently displayed style
-  Future<void> addImageFromUrl(String name, String url) async {
-    var response = await get(url);
-    return controller.addImage(name, response.bodyBytes);
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -213,6 +219,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
             height: 200.0,
             child: MapboxMap(
               onMapCreated: _onMapCreated,
+              onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),
                 zoom: 11.0,
@@ -248,17 +255,13 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                           child: const Text('add (asset image)'),
                           onPressed: () => (_symbolCount == 12)
                               ? null
-                              : addImageFromAsset(
-                                      "testAsset", "assets/symbols/custom-icon.png")
-                                  .then((_) => _add("testAsset")),
+                              : _add(
+                                  "assetImage"), //assetImage added to the style in _onStyleLoaded
                         ),
                         FlatButton(
                           child: const Text('add (network image)'),
-                          onPressed: () => (_symbolCount == 12)
-                              ? null
-                              : addImageFromUrl(
-                                      "testNetwork", "https://via.placeholder.com/30")
-                                  .then((_) => _add("testNetwork")),
+                          onPressed: () =>
+                              (_symbolCount == 12) ? null : _add("networkImage"), //networkImage added to the style in _onStyleLoaded
                         ),
                       ],
                     ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
   location: ^2.5.3
+  http:
 
 dev_dependencies:
   flutter_test:

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -278,6 +278,16 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+        case "style#addImage":
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let name = arguments["name"] as? String else { return }
+            //guard let length = arguments["length"] as? NSNumber else { return }
+            guard let bytes = arguments["bytes"] as? FlutterStandardTypedData else { return }
+            guard let data = bytes.data as? Data else{ return }
+            guard let image = UIImage(data: data) else { return }
+            
+            self.mapView.style?.setImage(image, forName: name)
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -6,6 +6,7 @@ library mapbox_gl;
 
 import 'dart:async';
 import 'dart:math';
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -663,7 +663,7 @@ class MapboxMapController extends ChangeNotifier {
   /// Adds an image to the style currently displayed in the map, so that it can later be referred to by the provided name.
   /// 
   /// This allows you to add an image to the currently displayed style once, and from there on refer to it e.g. in the [Symbol.iconImage] anytime you add a [Symbol] later on.
-  /// Set [sdf] to true if the image you add is a SDF image.
+  /// Set [sdf] to true if the image you add is an SDF image.
   /// Returns after the image has successfully been added to the style.
   /// Note: This can only be called after OnStyleLoadedCallback has been invoked and any added images will have to be re-added if a new style is loaded.
   /// 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -662,7 +662,8 @@ class MapboxMapController extends ChangeNotifier {
 
   /// Adds an image to the style currently displayed in the map, so that it can later be referred to by the provided name.
   /// 
-  /// This e.g. allows you to refer to the added image in the [Symbol.iconImage] when adding Symbols later on.
+  /// This allows you to add an image to the currently displayed style once, and from there on refer to it e.g. in the [Symbol.iconImage] anytime you add a [Symbol] later on.
+  /// Set [sdf] to true if the image you add is a SDF image.
   /// Returns after the image has successfully been added to the style.
   /// Note: This can only be called after OnStyleLoadedCallback has been invoked and any added images will have to be re-added if a new style is loaded.
   /// 
@@ -694,12 +695,13 @@ class MapboxMapController extends ChangeNotifier {
   ///  );
   /// }
   /// ```
-  Future<void> addImage(String name, Uint8List bytes) {
+  Future<void> addImage(String name, Uint8List bytes, [bool sdf = false]) {
     try {
       return _channel.invokeMethod('style#addImage', <String, Object>{
         "name": name,
         "bytes": bytes,
-        "length": bytes.length
+        "length": bytes.length,
+        "sdf": sdf
       });
     } on PlatformException catch (e) {
       return new Future.error(e);

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -659,4 +659,54 @@ class MapboxMapController extends ChangeNotifier {
       return new Future.error(e);
     }
   }
+
+  /// Adds an image to the style currently displayed in the map, so that it can later be referred to by the provided name.
+  /// 
+  /// This e.g. allows you to refer to the added image in the [Symbol.iconImage] when adding Symbols later on.
+  /// Returns after the image has successfully been added to the style.
+  /// Note: This can only be called after OnStyleLoadedCallback has been invoked and any added images will have to be re-added if a new style is loaded.
+  /// 
+  /// Example: Adding an asset image and using it in a new symbol:
+  /// ```dart
+  /// Future<void> addImageFromAsset() async{
+  ///   final ByteData bytes = await rootBundle.load("assets/someAssetImage.jpg");
+  ///   final Uint8List list = bytes.buffer.asUint8List();
+  ///   await controller.addImage("assetImage", list);
+  ///   controller.addSymbol(
+  ///    SymbolOptions(
+  ///     geometry: LatLng(0,0),
+  ///     iconImage: "assetImage",
+  ///    ),
+  ///   );
+  /// }
+  /// ```
+  /// 
+  /// Example: Adding a network image (with the http package) and using it in a new symbol:
+  /// ```dart
+  /// Future<void> addImageFromUrl() async{
+  ///  var response = await get("https://example.com/image.png");
+  ///  await controller.addImage("testImage",  response.bodyBytes);
+  ///  controller.addSymbol(
+  ///   SymbolOptions(
+  ///     geometry: LatLng(0,0),
+  ///     iconImage: "testImage",
+  ///   ),
+  ///  );
+  /// }
+  /// ```
+  Future<void> addImage(String name, Uint8List bytes) {
+    try {
+      return _channel.invokeMethod('style#addImage', <String, Object>{
+        "name": name,
+        "bytes": bytes,
+        "length": bytes.length
+      });
+    } on PlatformException catch (e) {
+      return new Future.error(e);
+    }
+  }
+
+  
+
+ 
 }


### PR DESCRIPTION
This implements a new addImage() method, which allows adding arbitrary images to the currently displayed style. Therefore it's now possible to add e.g. network images at runtime as requested in #234. I also added an example.
Also addImage() exposes an sdf flag for adding sdf icons, which should theoretically allow for recoloring icons (#77), but I haven't tested this, yet, because I didn't have an SDF icon at hand.

**Edit**: Now implemented on android and ios.
