### PR TITLE
CI: use stable flutter channel also on iOS

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -7,7 +7,6 @@ jobs:
     name: "Static code analysis"
     runs-on: ubuntu-latest
 
-
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
@@ -29,7 +28,6 @@ jobs:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
     - run: flutter pub get
-
     - name: Build example APK
       run: cd example && flutter build apk
       # We might want to add a flutter test step in the future, when there actually are tests for this plugin
@@ -37,16 +35,14 @@ jobs:
   build-iOS:
     name: Build iOS package
     runs-on: macos-latest
+    
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
-      - name: Upgrade flutter
-        run: |
-          flutter channel master
-          flutter upgrade
+      - run: flutter pub get
       - name: build iOS package
         run: |
           cd ./example


### PR DESCRIPTION
Right now the linter and the android build use the latest flutter release from the stable channel, while for iOS first the latest stable release is installed, and then flutter is (inefficiently) changed to the master channel.
This makes all three jobs use the latest stable release.