### PR TITLE
Add First-Class Support For Listening to `onCameraIdle` events

### DIFF
--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -41,6 +41,7 @@ class MoveCameraState extends State<MoveCamera> {
             height: 200.0,
             child: MapboxMap(
               onMapCreated: _onMapCreated,
+              onCameraIdle: ()=>print("onCameraIdle"),
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),
             ),

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -11,6 +11,8 @@ typedef void OnStyleLoadedCallback();
 typedef void OnCameraTrackingDismissedCallback();
 typedef void OnCameraTrackingChangedCallback(MyLocationTrackingMode mode);
 
+typedef void OnCameraIdleCallback();
+
 typedef void OnMapIdleCallback();
 
 /// Controller for a single MapboxMap instance running on the host platform.
@@ -35,6 +37,7 @@ class MapboxMapController extends ChangeNotifier {
       this.onMapClick,
       this.onCameraTrackingDismissed,
       this.onCameraTrackingChanged,
+      this.onCameraIdle,
       this.onMapIdle})
       : assert(_id != null),
         assert(channel != null),
@@ -49,6 +52,7 @@ class MapboxMapController extends ChangeNotifier {
       OnMapClickCallback onMapClick,
       OnCameraTrackingDismissedCallback onCameraTrackingDismissed,
       OnCameraTrackingChangedCallback onCameraTrackingChanged,
+      OnCameraIdleCallback onCameraIdle,
       OnMapIdleCallback onMapIdle}) async {
     assert(id != null);
     final MethodChannel channel =
@@ -59,6 +63,7 @@ class MapboxMapController extends ChangeNotifier {
         onMapClick: onMapClick,
         onCameraTrackingDismissed: onCameraTrackingDismissed,
         onCameraTrackingChanged: onCameraTrackingChanged,
+        onCameraIdle: onCameraIdle,
         onMapIdle: onMapIdle);
   }
 
@@ -70,6 +75,8 @@ class MapboxMapController extends ChangeNotifier {
 
   final OnCameraTrackingDismissedCallback onCameraTrackingDismissed;
   final OnCameraTrackingChangedCallback onCameraTrackingChanged;
+
+  final OnCameraIdleCallback onCameraIdle;
 
   final OnMapIdleCallback onMapIdle;
 
@@ -155,6 +162,9 @@ class MapboxMapController extends ChangeNotifier {
         break;
       case 'camera#onIdle':
         _isCameraMoving = false;
+        if (onCameraIdle != null) {
+          onCameraIdle();
+        }
         notifyListeners();
         break;
       case 'map#onStyleLoaded':

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -31,6 +31,7 @@ class MapboxMap extends StatefulWidget {
     this.onMapClick,
     this.onCameraTrackingDismissed,
     this.onCameraTrackingChanged,
+    this.onCameraIdle,
     this.onMapIdle,
   }) : assert(initialCameraPosition != null);
 
@@ -134,6 +135,9 @@ class MapboxMap extends StatefulWidget {
   final OnCameraTrackingDismissedCallback onCameraTrackingDismissed;
   final OnCameraTrackingChangedCallback onCameraTrackingChanged;
 
+  // Called when camera movement has ended.
+  final OnCameraIdleCallback onCameraIdle;
+
   /// Called when map view is entering an idle state, and no more drawing will
   /// be necessary until new data is loaded or there is some interaction with
   /// the map.
@@ -211,6 +215,7 @@ class _MapboxMapState extends State<MapboxMap> {
         onMapClick: widget.onMapClick,
         onCameraTrackingDismissed: widget.onCameraTrackingDismissed,
         onCameraTrackingChanged: widget.onCameraTrackingChanged,
+        onCameraIdle: widget.onCameraIdle,
         onMapIdle: widget.onMapIdle);
     _controller.complete(controller);
     if (widget.onMapCreated != null) {


### PR DESCRIPTION
I believe the use case for the `onCameraIdle` event [1] is large enough
that this event should be able to be listened to directly without having
to listen to extraneous events via the ChangeNotifier interface. The
extraneous events which I think add too much noise when combined with
the camera idle event include:

* Camera Start/Move Events
* Updating Map Options
* Adding/Updating/Removing/Clearing a Symbol, Line, or Circle

For example, the use case described in #131 where a client wants to
display symbols within a bounding box after a user pans the map should
be able to have first-class support. FWIW, other flutter mapping plugins
provide this ability, and it is very useful [2].

Usage:

```
MapboxMap(
  onCameraIdle: () {
    print("Camera has idled.");
  },
);
```

[1] https://github.com/tobrun/flutter-mapbox-gl/blob/1bbe7ea7adc8030af16a3cdbf5ade2f94ddea6bd/lib/src/controller.dart#L156
[2] https://github.com/flutter/plugins/blob/61775d32f1d1f0997e0e93bb1e8676b96be9d848/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart#L136