### PR TITLE
Update Android Mapbox plugins and gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,9 +37,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     dependencies {
-        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:8.5.0"
-        implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.7.0"
-        implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v8:0.11.0'		
+        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0"
+        implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0"
+        implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0"
     }
     compileOptions {
         sourceCompatibility 1.8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.6.1'
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Mon May 25 15:33:34 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/example/android/settings_aar.gradle
+++ b/example/android/settings_aar.gradle
@@ -1,0 +1,1 @@
+include ':app'


### PR DESCRIPTION
I upgraded the Mapbox sdk and the two Mapbox plugins we are using to the latest version, as well as gradle, because the older gradle version didn't play nicely with the new Mapbox plugins.
This should fix #263 and hopefully also #248 
Big thanks to @AAverin for keeping track of the fix upstream.