### PR TITLE
[fix] Change default MyLocationTrackingMode to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add these lines to your Info.plist
 <key>MGLMapboxAccessToken</key>
 <string>YOUR_TOKEN_HERE</string>
 ```
-You should also add the following key to your Info.plist to explain to your users why you need to access their location:
+If you access your users' location, you should also add the following key to your Info.plist to explain why you need access to their location data:
 ```
 <key>NSLocationWhenInUseUsageDescription</key>
 <string>[Your explanation here]</string>

--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ Add Mapbox read token value in the application manifest ```android/app/src/main/
 #### iOS
 Add these lines to your Info.plist
 
-```plist
+```
 <key>io.flutter.embedded_views_preview</key>
 <true/>
 <key>MGLMapboxAccessToken</key>
 <string>YOUR_TOKEN_HERE</string>
 ```
-
+You should also add the following key to your Info.plist to explain to your users why you need to access their location:
+```
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>[Your explanation here]</string>
+```
+Mapbox [recommends](https://docs.mapbox.com/help/tutorials/first-steps-ios-sdk/#display-the-users-location) the explanation "Shows your location on the map and helps improve the map".
 ## Supported API
 
 | Feature | Android | iOS |

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -22,7 +22,7 @@ class MapboxMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.trackCameraPosition = false,
     this.myLocationEnabled = false,
-    this.myLocationTrackingMode = MyLocationTrackingMode.Tracking,
+    this.myLocationTrackingMode = MyLocationTrackingMode.None,
     this.myLocationRenderMode = MyLocationRenderMode.COMPASS,
     this.logoViewMargins,
     this.compassViewPosition,


### PR DESCRIPTION
Fixes #218 
As explained in #218, it's currently impossible to use this plugin on iOS without specifying the `NSLocationWhenInUseUsageDescription` key in Info.plist. I found out that this is, because the default MyLocationTrackingMode was set to compass, leading the Mapbox iOS SDK to ask for location permissions. This would in turn lead to the app crashing if the appropriate keys weren't defined in Info.plist as required by Apple. 
With this change, the default is now to not require location permissions, so that users can display maps without asking for this sensitive permission if it's not necessary. 