### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.0.6, May 31, 2019
+* Update mapbox depdendency to 9.2.0 (android) and 5.6.0 (iOS)
+* Long press handlers for both iOS as Android
+* Change default location tracking to none
+* OnCameraIdle listener support 
+* Add image to style 
+* Add animation duration to animateCamera
+* Content insets
+* Visible region support on iOS
+* Numerous bug fixes 
+
 ## 0.0.5, December 21, 2019
 * iOS support for annotation extensions (circle, symbol, line)
 * Update SDK to 8.5.0 (Android) and 5.5.0 (iOS)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,7 @@
 name: mapbox_gl
 description: A Flutter plugin for integrating Mapbox Maps SDK inside a Flutter widget in iOS and Android applications.
-version: 0.0.5
-author: Mapbox <tobrun@mapbox.com>
+version: 0.0.6
 homepage: https://github.com/tobrun/flutter-mapbox-gl
-
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR release v0.6.0 of the flutter-mapbox-gl plugin.
Author tagged was removed from pubspec.yaml as this was deprecated.
Thanks to all who contributed!