### PR TITLE
Update README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,28 @@
-# Flutter Mapbox GL Native
+# Flutter Mapbox GL
 
 > **Please note that this project is community driven and is not an official Mapbox product.** We welcome [feedback](https://github.com/tobrun/flutter-mapbox-gl/issues) and contributions.
 
-This Flutter plugin for [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) enables
-embedded interactive and customizable vector maps inside a Flutter widget by embedding Android and iOS views.
+This Flutter plugin allows to show embedded interactive and customizable vector maps inside a Flutter widget. For the Android and iOS integration, we use [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native). For web, we rely on [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js). This project only supports a subset of the API exposed by these libraries. 
 
 ![screenshot.png](screenshot.png)
 
-## Install
-
-This project is available on [pub.dev](https://pub.dev/packages/mapbox_gl), follow the [instructions](https://flutter.dev/docs/development/packages-and-plugins/using-packages#adding-a-package-dependency-to-an-app) to integrate a package into your flutter application.
-
-## :new: :new: Who's using this SDK :new: :new:
-
-We're compiling a list of apps using this SDK. If you want to be listed here, please open a PR and add yourself below (or open a ticket and we'll add you).
-
-- You?
-
-### Running example app
+## Running the example app
 
 - Install [Flutter](https://flutter.io/get-started/) and validate its installation with `flutter doctor`
-- Clone this repository with `git clone git@github.com:mapbox/flutter-mapbox-gl.git`
-- Run the app with `cd flutter_mapbox/example && flutter run`
+- Clone the repository with `git clone git@github.com:mapbox/flutter-mapbox-gl.git`
+- Add a Mapbox access token to the example app (see next section)
+- Connect a mobile device or start an emulator, simulator or chrome
+- Locate the id of a the device with `flutter devices`
+- Run the app with `cd flutter_mapbox/example && flutter packages get && flutter run -d {device_id}``
 
-#### Mapbox Access Token
+### Adding a Mapbox Access Token
 
 This project uses Mapbox vector tiles, which requires a Mapbox account and a Mapbox access token. Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
 > **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) with this plugin, you will need to specify any non-empty string as Access Token as explained below!**
 
 ##### Android
 
-Add Mapbox read token value in the application manifest ```android/app/src/main/AndroidManifest.xml:```
+Add Mapbox access token configuration in the application manifest `example/android/app/src/main/AndroidManifest.xml`:
 
 ```xml
 <manifest ...
@@ -40,7 +32,7 @@ Add Mapbox read token value in the application manifest ```android/app/src/main/
 
 ##### iOS
 
-Add these lines to your Info.plist
+Add Mapbox access token configuration to the application Info.plist `example/ios/Runner/Info.plist`:
 
 ```xml
 <key>io.flutter.embedded_views_preview</key>
@@ -49,27 +41,9 @@ Add these lines to your Info.plist
 <string>YOUR_TOKEN_HERE</string>
 ```
 
-If you access your users' location, you should also add the following key to your Info.plist to explain why you need access to their location data:
-
-```xml
-<key>NSLocationWhenInUseUsageDescription</key>
-<string>[Your explanation here]</string>
-```
-
-Mapbox [recommends](https://docs.mapbox.com/help/tutorials/first-steps-ios-sdk/#display-the-users-location) the explanation "Shows your location on the map and helps improve the map".
-
 ##### Web
 
-Add mapbox-gl.js library in the `<head>` of your html page:
-
-```html
-<head>
-  ...
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
-</head>
-```
-
-Add your `accessToken` in a script tag at the end of your body:
+Add Mapbox access token configuration to index.html `example/web/index.html`:
 
 ```html
 <body>
@@ -79,6 +53,10 @@ Add your `accessToken` in a script tag at the end of your body:
   </script>
 </body>
 ```
+
+## Using the SDK in your project
+
+This project is available on [pub.dev](https://pub.dev/packages/mapbox_gl), follow the [instructions](https://flutter.dev/docs/development/packages-and-plugins/using-packages#adding-a-package-dependency-to-an-app) to integrate a package into your flutter application. For platform specific integration, use the flutter application under the example folder as reference. 
 
 ## Supported API
 
@@ -116,6 +94,19 @@ Support for offline maps is available by *"side loading"* the required map tiles
     }
 ```
 
+## Location features
+
+To enable location features in an iOS application:
+
+If you access your users' location, you should also add the following key to your Info.plist to explain why you need access to their location data:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>[Your explanation here]</string>
+```
+
+Mapbox [recommends](https://docs.mapbox.com/help/tutorials/first-steps-ios-sdk/#display-the-users-location) the explanation "Shows your location on the map and helps improve the map".
+
 ## Documentation
 
 This README file currently houses all of the documentation for this Flutter project. Please visit [mapbox.com/android-docs](https://www.mapbox.com/android-docs/) if you'd like more information about the Mapbox Maps SDK for Android and [mapbox.com/ios-sdk](https://www.mapbox.com/ios-sdk/) for more information about the Mapbox Maps SDK for iOS.
@@ -126,12 +117,7 @@ This README file currently houses all of the documentation for this Flutter proj
 - **Have a bug to report?** [Open an issue](https://github.com/tobrun/flutter-mapbox-gl/issues/new). If possible, include a full log and information which shows the issue.
 - **Have a feature request?** [Open an issue](https://github.com/tobrun/flutter-mapbox-gl/issues/new). Tell us what the feature should do and why you want the feature.
 
-## Sample code
-
-[This repository's example library](https://github.com/tobrun/flutter-mapbox-gl/tree/master/example/lib) is currently the best place for you to find reference code for this project.
 
 ## Contributing
 
-We welcome contributions to this repository!
-
-If you're interested in helping build this Mapbox/Flutter integration, please read [the contribution guide](https://github.com/tobrun/flutter-mapbox-gl/blob/master/CONTRIBUTING.md) to learn how to get started.
+We welcome contributions to this repository! If you're interested in helping build this Mapbox/Flutter integration, please read [the contribution guide](https://github.com/tobrun/flutter-mapbox-gl/blob/master/CONTRIBUTING.md) to learn how to get started.


### PR DESCRIPTION
Closes #296, make running example apps more concrete. 
Update content to resemble support for web through `mapbox-gl-js`. 

