### PR TITLE
Release v0.7.0 of flutter plugin for mapbox maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0, June 6, 2020
+* Introduction of mapbox_gl_platform_interface library
+* Introduction of mapbox_gl_web library
+* Integrate web support through mapbox-gl-js
+* Add icon-allow-overlap configurations
+
 ## 0.0.6, May 31, 2020
 * Update mapbox depdendency to 9.2.0 (android) and 5.6.0 (iOS)
 * Long press handlers for both iOS as Android

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/mapbox_gl_platform_interface/CHANGELOG.md
+++ b/mapbox_gl_platform_interface/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.7.0
+- Initial version

--- a/mapbox_gl_platform_interface/LICENSE
+++ b/mapbox_gl_platform_interface/LICENSE
@@ -1,0 +1,6 @@
+flutter-mapbox-gl copyright (c) 2018, Mapbox.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mapbox_gl_platform_interface/README.md
+++ b/mapbox_gl_platform_interface/README.md
@@ -1,0 +1,1 @@
+Contains the web platform implementation for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).

--- a/mapbox_gl_platform_interface/pubspec.yaml
+++ b/mapbox_gl_platform_interface/pubspec.yaml
@@ -1,6 +1,7 @@
 name: mapbox_gl_platform_interface
 description: A common platform interface for the mapbox_gl plugin.
-version: 0.1.0
+version: 0.7.0
+homepage: https://github.com/tobrun/flutter-mapbox-gl
 
 dependencies:
   flutter:

--- a/mapbox_gl_web/CHANGELOG.md
+++ b/mapbox_gl_web/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.7.0
+- Initial version

--- a/mapbox_gl_web/LICENSE
+++ b/mapbox_gl_web/LICENSE
@@ -1,0 +1,6 @@
+flutter-mapbox-gl copyright (c) 2018, Mapbox.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mapbox_gl_web/README.md
+++ b/mapbox_gl_web/README.md
@@ -1,0 +1,1 @@
+Contains the web interfaces for the [Flutter Mapbox GL plugin](https://github.com/tobrun/flutter-mapbox-gl).

--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mapbox_gl_web
-description: Web platform implementation of mapbox_gl_web
-version: 0.1.0
-homepage: https://github.com/tobrun/flutter-mapbox-gl/mapbox_gl_web
+description: Web platform implementation of mapbox_gl
+version: 0.7.0
+homepage: https://github.com/tobrun/flutter-mapbox-gl
 
 flutter:
   plugin:
@@ -16,8 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.1.7
-  mapbox_gl_platform_interface: 
-    path: ../mapbox_gl_platform_interface
+  mapbox_gl_platform_interface: ^0.7.0
   mapbox_gl_dart: ^0.1.5
   image: ^2.1.12
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,13 @@
 name: mapbox_gl
-description: A Flutter plugin for integrating Mapbox Maps SDK inside a Flutter widget in iOS and Android applications.
-version: 0.0.6
+description: A Flutter plugin for integrating Mapbox Maps inside a Flutter application on Android, iOS and web platfroms.
+version: 0.7.0
 homepage: https://github.com/tobrun/flutter-mapbox-gl
 
 dependencies:
   flutter:
     sdk: flutter
-  mapbox_gl_platform_interface:
-    path: ./mapbox_gl_platform_interface
-  mapbox_gl_web:
-    path: ./mapbox_gl_web
+  mapbox_gl_platform_interface: ^0.7.0
+  mapbox_gl_web: ^0.7.0
     
 flutter:
   plugin:


### PR DESCRIPTION
PR updates files for the v0.7.0 release of:
 - sdk
 - platform interface
 - web interface

note: I mistakenly jumped in version numbering when publishing platform interface and web interface, I couldn't change this after the facts.