### PR TITLE
Fix Android's `zIndex` SymbolOption

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -374,7 +374,7 @@ class Convert {
     if (geometry != null) {
       sink.setGeometry(toLatLng(geometry));
     }
-    final Object symbolSortKey = data.get("symbolSortKey");
+    final Object symbolSortKey = data.get("zIndex");
     if (symbolSortKey != null) {
       sink.setSymbolSortKey(toFloat(symbolSortKey));
     }


### PR DESCRIPTION
Before this commit, passing the `zIndex` SymbolOption would be inert as
the Android implementation thought this option was called
'symbolSortKey'. This commit corrects that so that the Android zIndex
implementation works again.