### PR TITLE
Fix `onCameraIdle` callback not being invoked

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -83,6 +83,9 @@ class MapboxMapController extends ChangeNotifier {
 
     MapboxGlPlatform.instance.onCameraIdlePlatform.add((_) {
       _isCameraMoving = false;
+      if (onCameraIdle != null) {
+        onCameraIdle();
+      }
       notifyListeners();
     });
 


### PR DESCRIPTION
It looks like this invocation was accidentally removed in
ebef5dbaede55e6f1ccfca496f5b04589245ac53 which prevents the firing of
`onCameraIdle` (if the client passes this option). This commit adds this
functionality back in.