### PR TITLE
Set dependencies from git

### DIFF
--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -18,9 +18,8 @@ dependencies:
   meta: ^1.1.7
   mapbox_gl_platform_interface:
     git:
-      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      url: git@github.com:tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_platform_interface
-      ref: dependencies-from-git
   mapbox_gl_dart: ^0.1.5
   image: ^2.1.12
 

--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   meta: ^1.1.7
   mapbox_gl_platform_interface:
     git:
-      url: git@github.com:tobrun/flutter-mapbox-gl.git
+      url: https://github.com/tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_platform_interface
   mapbox_gl_dart: ^0.1.5
   image: ^2.1.12

--- a/mapbox_gl_web/pubspec.yaml
+++ b/mapbox_gl_web/pubspec.yaml
@@ -16,8 +16,11 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.1.7
-  mapbox_gl_platform_interface: 
-    path: ../mapbox_gl_platform_interface
+  mapbox_gl_platform_interface:
+    git:
+      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      path: mapbox_gl_platform_interface
+      ref: dependencies-from-git
   mapbox_gl_dart: ^0.1.5
   image: ^2.1.12
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,14 +8,12 @@ dependencies:
     sdk: flutter
   mapbox_gl_platform_interface:
     git:
-      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      url: git@github.com:tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_platform_interface
-      ref: dependencies-from-git
   mapbox_gl_web:
     git:
-      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      url: git@github.com:tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_web
-      ref: dependencies-from-git
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ dependencies:
     sdk: flutter
   mapbox_gl_platform_interface:
     git:
-      url: git@github.com:tobrun/flutter-mapbox-gl.git
+      url: https://github.com/tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_platform_interface
   mapbox_gl_web:
     git:
-      url: git@github.com:tobrun/flutter-mapbox-gl.git
+      url: https://github.com/tobrun/flutter-mapbox-gl.git
       path: mapbox_gl_web
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,11 +6,17 @@ homepage: https://github.com/tobrun/flutter-mapbox-gl
 dependencies:
   flutter:
     sdk: flutter
-  mapbox_gl_platform_interface: 
-    path: mapbox_gl_platform_interface
-  mapbox_gl_web: 
-    path: mapbox_gl_web
-    
+  mapbox_gl_platform_interface:
+    git:
+      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      path: mapbox_gl_platform_interface
+      ref: dependencies-from-git
+  mapbox_gl_web:
+    git:
+      url: git@github.com:andrea689/flutter-mapbox-gl.git
+      path: mapbox_gl_web
+      ref: dependencies-from-git
+
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
@tobrun @m0nac0 What do you think if we set the dependencies from git? In this way anyone can use the master branch in their projects without problems even if `mapbox_gl_platform_interface` and` mapbox_gl_web` are not yet published.