### PR TITLE
Allow setting access token in Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,44 +15,15 @@ This Flutter plugin allows to show embedded interactive and customizable vector 
 - Locate the id of a the device with `flutter devices`
 - Run the app with `cd flutter_mapbox/example && flutter packages get && flutter run -d {device_id}`
 
-### Adding a Mapbox Access Token
+## Adding a Mapbox Access Token
 
 This project uses Mapbox vector tiles, which requires a Mapbox account and a Mapbox access token. Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
 > **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) with this plugin, you will need to specify any non-empty string as Access Token as explained below!**
 
-##### Android
 
-Add Mapbox access token configuration in the application manifest `example/android/app/src/main/AndroidManifest.xml`:
+The **recommended** way to provide your access token is in the `MapboxMap` constructor's `accessToken` parameter, which is available starting from the v0.8 release. Note that you should always use the same token throughout your entire app.
 
-```xml
-<manifest ...
-  <application ...
-    <meta-data android:name="com.mapbox.token" android:value="YOUR_TOKEN_HERE" />
-```
-
-##### iOS
-
-Add Mapbox access token configuration to the application Info.plist `example/ios/Runner/Info.plist`:
-
-```xml
-<key>io.flutter.embedded_views_preview</key>
-<true/>
-<key>MGLMapboxAccessToken</key>
-<string>YOUR_TOKEN_HERE</string>
-```
-
-##### Web
-
-Add Mapbox access token configuration to index.html `example/web/index.html`:
-
-```html
-<body>
-  ...
-  <script>
-    mapboxgl.accessToken = 'YOUR_TOKEN_HERE';
-  </script>
-</body>
-```
+An alternative way to provide access tokens, which was required until the v0.7 release, is described in [this wiki article](https://github.com/tobrun/flutter-mapbox-gl/wiki/Mapbox-access-tokens).
 
 ## Using the SDK in your project
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This project uses Mapbox vector tiles, which requires a Mapbox account and a Map
 > **Even if you do not use Mapbox vector tiles but vector tiles from a different source (like self-hosted tiles) with this plugin, you will need to specify any non-empty string as Access Token as explained below!**
 
 
-The **recommended** way to provide your access token is in the `MapboxMap` constructor's `accessToken` parameter, which is available starting from the v0.8 release. Note that you should always use the same token throughout your entire app.
+The **recommended** way to provide your access token is through the `MapboxMap` constructor's `accessToken` parameter, which is available starting from the v0.8 release. Note that you should always use the same token throughout your entire app.
 
-An alternative way to provide access tokens, which was required until the v0.7 release, is described in [this wiki article](https://github.com/tobrun/flutter-mapbox-gl/wiki/Mapbox-access-tokens).
+An alternative method to provide access tokens that was required until the v0.7 release is described in [this wiki article](https://github.com/tobrun/flutter-mapbox-gl/wiki/Mapbox-access-tokens).
 
 ## Using the SDK in your project
 

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -30,9 +30,9 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private String styleString = Style.MAPBOX_STREETS;
 
   MapboxMapController build(
-    int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar) {
+    int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar, String accessToken) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context, state, registrar, options, styleString);
+      new MapboxMapController(id, context, state, registrar, options, accessToken, styleString);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -134,6 +134,7 @@ final class MapboxMapController
     AtomicInteger activityState,
     PluginRegistry.Registrar registrar,
     MapboxMapOptions options,
+    String accessToken,
     String styleStringInitial) {
     Mapbox.getInstance(context, accessToken!=null ? accessToken : getAccessToken(context));
     this.id = id;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -135,7 +135,7 @@ final class MapboxMapController
     PluginRegistry.Registrar registrar,
     MapboxMapOptions options,
     String styleStringInitial) {
-    Mapbox.getInstance(context, getAccessToken(context));
+    Mapbox.getInstance(context, accessToken!=null ? accessToken : getAccessToken(context));
     this.id = id;
     this.context = context;
     this.activityState = activityState;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -34,6 +34,6 @@ public class MapboxMapFactory extends PlatformViewFactory {
       CameraPosition position = Convert.toCameraPosition(params.get("initialCameraPosition"));
       builder.setInitialCameraPosition(position);
     }
-    return builder.build(id, context, mActivityState, mPluginRegistrar);
+    return builder.build(id, context, mActivityState, mPluginRegistrar, (String) params.get("accessToken"));
   }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
         android:name="io.flutter.app.FlutterApplication"
         android:label="mapbox_gl_example"
         android:icon="@mipmap/ic_launcher">
-        <meta-data android:name="com.mapbox.token" android:value="@string/mapbox_access_token" />
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/example/android/app/src/main/res/values/developer-config.xml
+++ b/example/android/app/src/main/res/values/developer-config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_access_token">ADD_MAPBOX_ACCESS_TOKEN_HERE</string>
-</resources>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,13 +43,11 @@
 	<false/>
 	<key>io.flutter.embedded_views_preview</key>
 	<true/>
-	<key>MGLMapboxAccessToken</key>
-	<string>YOUR_TOKEN_HERE</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string>Shows your location on the map and helps improve the map</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string></string>
+	<string>Shows your location on the map and helps improve the map</string>
 </dict>
 </plist>

--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class AnimateCameraPage extends ExamplePage {
@@ -41,6 +42,7 @@ class AnimateCameraState extends State<AnimateCamera> {
             width: 300.0,
             height: 200.0,
             child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class FullMapPage extends ExamplePage {
@@ -31,6 +32,7 @@ class FullMapState extends State<FullMap> {
   Widget build(BuildContext context) {
     return new Scaffold(
         body: MapboxMap(
+          accessToken: MapsDemo.ACCESS_TOKEN,
           onMapCreated: _onMapCreated,
           initialCameraPosition:
           const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class LinePage extends ExamplePage {
@@ -144,6 +145,7 @@ class LineBodyState extends State<LineBody> {
             width: 300.0,
             height: 200.0,
             child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: onStyleLoadedCallback,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,10 @@ final List<ExamplePage> _allPages = <ExamplePage>[
 ];
 
 class MapsDemo extends StatelessWidget {
+
+  //FIXME: Add your Mapbox access token here
+  static const String ACCESS_TOKEN = "YOUR_TOKEN_HERE";
+
   void _pushPage(BuildContext context, ExamplePage page) async {
     if (!kIsWeb) {
       final location = Location();

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 final LatLngBounds sydneyBounds = LatLngBounds(
@@ -224,6 +225,7 @@ class MapUiBodyState extends State<MapUiBody> {
   @override
   Widget build(BuildContext context) {
     final MapboxMap mapboxMap = MapboxMap(
+      accessToken: MapsDemo.ACCESS_TOKEN,
       onMapCreated: onMapCreated,
       initialCameraPosition: _kInitialPosition,
       trackCameraPosition: true,

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class MoveCameraPage extends ExamplePage {
@@ -40,6 +41,7 @@ class MoveCameraState extends State<MoveCamera> {
             width: 300.0,
             height: 200.0,
             child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onCameraIdle: ()=>print("onCameraIdle"),
               initialCameraPosition:

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class PlaceCirclePage extends ExamplePage {
@@ -217,6 +218,7 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
             width: 300.0,
             height: 200.0,
             child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class PlaceSymbolPage extends ExamplePage {
@@ -274,6 +275,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
             width: 300.0,
             height: 200.0,
             child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 class ScrollingMapPage extends ExamplePage {
@@ -50,6 +51,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                     width: 300.0,
                     height: 300.0,
                     child: MapboxMap(
+                      accessToken: MapsDemo.ACCESS_TOKEN,
                       onMapCreated: onMapCreatedOne,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
                       initialCameraPosition: CameraPosition(
@@ -85,6 +87,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                     width: 300.0,
                     height: 300.0,
                     child: MapboxMap(
+                      accessToken: MapsDemo.ACCESS_TOKEN,
                       onMapCreated: onMapCreatedTwo,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
                       initialCameraPosition: CameraPosition(

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -32,8 +32,5 @@
     }
   </script>
   <script src="main.dart.js" type="application/javascript"></script>
-  <script>
-    mapboxgl.accessToken = 'YOUR_TOKEN_HERE';
-  </script>
 </body>
 </html>

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -26,6 +26,11 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     }
     
     init(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?, registrar: FlutterPluginRegistrar) {
+        if let args = args as? [String: Any] {
+            if let token = args["accessToken"] as? NSString{
+                MGLAccountManager.accessToken = token
+            }
+        }
         mapView = MGLMapView(frame: frame)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.registrar = registrar

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -9,6 +9,7 @@ typedef void MapCreatedCallback(MapboxMapController controller);
 class MapboxMap extends StatefulWidget {
   const MapboxMap({
     @required this.initialCameraPosition,
+    this.accessToken,
     this.onMapCreated,
     this.onStyleLoadedCallback,
     this.gestureRecognizers,
@@ -35,6 +36,14 @@ class MapboxMap extends StatefulWidget {
     this.onCameraIdle,
     this.onMapIdle,
   }) : assert(initialCameraPosition != null);
+
+
+  /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
+  /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
+  /// The reccommended way is to use this parameter to set your access token, an alternative way to add your access tokens through external files is described in the plugin's README.
+  /// 
+  /// Note: You should not use this parameter AND set the access token through external files at the same time, and you should use the same token throughout the entire app.
+  final String accessToken;
 
   final MapCreatedCallback onMapCreated;
 
@@ -164,6 +173,7 @@ class _MapboxMapState extends State<MapboxMap> {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition?.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
+      'accessToken': widget.accessToken,
     };
     return _mapboxGlPlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -40,7 +40,7 @@ class MapboxMap extends StatefulWidget {
 
   /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
   /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
-  /// The reccommended way is to use this parameter to set your access token, an alternative way to add your access tokens through external files is described in the plugin's README.
+  /// The reccommended way is to use this parameter to set your access token, an alternative way to add your access tokens through external files is described in the plugin's wiki on Github.
   /// 
   /// Note: You should not use this parameter AND set the access token through external files at the same time, and you should use the same token throughout the entire app.
   final String accessToken;

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -44,6 +44,9 @@ class MapboxMapController extends MapboxGlPlatform
     await _addStylesheetToShadowRoot();
     if (_creationParams.containsKey('initialCameraPosition')) {
       var camera = _creationParams['initialCameraPosition'];
+      if (_creationParams.containsKey('accessToken')) {
+        Mapbox.accessToken = _creationParams['accessToken'];
+      }
       _map = MapboxMap(
         MapOptions(
           container: _mapElement,


### PR DESCRIPTION
This allows passing the Mapbox access token in flutter in the MapboxMap constructor. Alternatively, the old method of setting the access token through different files is still supported as a fallback if the `accessToken` parameter isn't set. As a positive side-effect this should make stealing tokens by reverse-engineering an app a bit harder.

Closes #41.