### PR TITLE
[iOS] Fire long click listener earlier

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -421,7 +421,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     *  After a long press invoke the map#onMapLongClick callback.
     */
     @objc @IBAction func handleMapLongPress(sender: UILongPressGestureRecognizer) {
-        //Only fire at the end of the long press
+        //Fire when the long press starts
         if (sender.state == .began) {
           // Get the CGPoint where the user tapped.
             let point = sender.location(in: mapView)

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -422,7 +422,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     */
     @objc @IBAction func handleMapLongPress(sender: UILongPressGestureRecognizer) {
         //Only fire at the end of the long press
-        if (sender.state == .ended) {
+        if (sender.state == .began) {
           // Get the CGPoint where the user tapped.
             let point = sender.location(in: mapView)
             let coordinate = mapView.convert(point, toCoordinateFrom: mapView)


### PR DESCRIPTION
Fixes #324 
The long click listener on iOS will now fire when the long click begins and not when the finger is lifted.