### PR TITLE
CompassViewPosition #344

### DIFF
--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -28,6 +28,7 @@ export 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart'
         MapboxStyles,
         MyLocationTrackingMode,
         MyLocationRenderMode,
+        CompassViewPosition,
         Circle,
         CircleOptions,
         Line,


### PR DESCRIPTION
CompassViewPosition was not added to mapbox_gl.dart.  
 We can't use CompassViewPosition enum that's why we cant add any value to compassViewPosition parameter of mapboxmap. After my commit, CompassViewPosition is ready to use. 