### PR TITLE
web: ignore myLocationTrackingMode if myLocationEnabled is false

### DIFF
--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -114,7 +114,8 @@ class MapboxMap extends StatefulWidget {
   /// when the map tries to turn on the My Location layer.
   final bool myLocationEnabled;
 
-  /// The mode used to let the map's camera follow the device's physical location
+  /// The mode used to let the map's camera follow the device's physical location. 
+  /// `myLocationEnabled` needs to be true for values other than `MyLocationTrackingMode.None` to work.
   final MyLocationTrackingMode myLocationTrackingMode;
 
   /// The mode to render the user location symbol

--- a/mapbox_gl_web/lib/src/convert.dart
+++ b/mapbox_gl_web/lib/src/convert.dart
@@ -45,6 +45,7 @@ class Convert {
       sink.setMyLocationEnabled(options['myLocationEnabled']);
     }
     if (options.containsKey('myLocationTrackingMode')) {
+      //Should not be invoked before sink.setMyLocationEnabled()
       sink.setMyLocationTrackingMode(options['myLocationTrackingMode']);
     }
     if (options.containsKey('myLocationRenderMode')) {

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -542,6 +542,10 @@ class MapboxMapController extends MapboxGlPlatform
 
   @override
   void setMyLocationTrackingMode(int myLocationTrackingMode) {
+    if(_geolocateControl==null){
+      //myLocationEnabled is false, ignore myLocationTrackingMode
+      return;
+    }
     if (myLocationTrackingMode == 0) {
       _addGeolocateControl(trackUserLocation: false);
     } else {


### PR DESCRIPTION
Fixes #362: If myLocationEnabled is false, the value of myLocationTrackingMode is now ignored on web. This was already the behavior on Android and I've also documented it.