### PR TITLE
[Android] Upgrade annotation plugin to v0.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     dependencies {
         implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0"
-        implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0"
+        implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0"
     }
     compileOptions {

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -783,11 +783,12 @@ final class MapboxMapController
   }
 
   @Override
-  public void onAnnotationClick(Annotation annotation) {
+  public boolean onAnnotationClick(Annotation annotation) {
     if (annotation instanceof Symbol) {
       final SymbolController symbolController = symbols.get(String.valueOf(annotation.getId()));
       if (symbolController != null) {
         symbolController.onTap();
+        return true;
       }
     }
 
@@ -795,6 +796,7 @@ final class MapboxMapController
       final LineController lineController = lines.get(String.valueOf(annotation.getId()));
       if (lineController != null) {
         lineController.onTap();
+        return true;
       }
     }
 
@@ -802,8 +804,10 @@ final class MapboxMapController
       final CircleController circleController = circles.get(String.valueOf(annotation.getId()));
       if (circleController != null) {
         circleController.onTap();
+        return true;
       }
     }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
v0.9 of the Android annotation plugin includes fixes for these two issues:
* the `draggable` property now works for all annotation types
* click events on annotations won't trigger map click events anymore (on Android, the issue persists on web)

Fixes #130. #348 is fixed for Android.