### PR TITLE
Split padding values in CameraUpdate.newLatLngBounds()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.0? ???
+* Breaking change: CameraUpdate.newLatLngBounds() now supports setting
+ different padding values for left, top, right, bottom with
+ default of 0 for all. Implementations using the old
+ approach with only one padding value for all edges
+ have to be updated.
+* ...
+
 ## 0.7.0, June 6, 2020
 * Introduction of mapbox_gl_platform_interface library
 * Introduction of mapbox_gl_web library

--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -75,8 +75,8 @@ class Convert {
       case "newLatLng":
         return CameraUpdateFactory.newLatLng(toLatLng(data.get(1)));
       case "newLatLngBounds":
-        return CameraUpdateFactory.newLatLngBounds(
-          toLatLngBounds(data.get(1)), toPixels(data.get(2), density));
+        return CameraUpdateFactory.newLatLngBounds(toLatLngBounds(data.get(1)), toPixels(data.get(2), density),
+            toPixels(data.get(3), density), toPixels(data.get(4), density), toPixels(data.get(5), density));
       case "newLatLngZoom":
         return CameraUpdateFactory.newLatLngZoom(toLatLng(data.get(1)), toFloat(data.get(2)));
       case "scrollBy":

--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -87,7 +87,9 @@ class AnimateCameraState extends State<AnimateCamera> {
                           southwest: const LatLng(-38.483935, 113.248673),
                           northeast: const LatLng(-8.982446, 153.823821),
                         ),
-                        10.0,
+                        left: 10,
+                        top: 5,
+                        bottom: 25,
                       ),
                     );
                   },

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -87,7 +87,9 @@ class MoveCameraState extends State<MoveCamera> {
                           southwest: const LatLng(-38.483935, 113.248673),
                           northeast: const LatLng(-8.982446, 153.823821),
                         ),
-                        10.0,
+                        left: 10,
+                        top: 5,
+                        bottom: 25,
                       ),
                     );
                   },

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -67,8 +67,11 @@ class Convert {
             return camera
         case "newLatLngBounds":
             guard let bounds = cameraUpdate[1] as? [[Double]] else { return nil }
-            guard let padding = cameraUpdate[2] as? CGFloat else { return nil }
-            return mapView.cameraThatFitsCoordinateBounds(MGLCoordinateBounds.fromArray(bounds), edgePadding: UIEdgeInsets.init(top: padding, left: padding, bottom: padding, right: padding))
+            guard let paddingLeft = cameraUpdate[2] as? CGFloat else { return nil }
+            guard let paddingTop = cameraUpdate[3] as? CGFloat else { return nil }
+            guard let paddingRight = cameraUpdate[4] as? CGFloat else { return nil }
+            guard let paddingBottom = cameraUpdate[5] as? CGFloat else { return nil }
+            return mapView.cameraThatFitsCoordinateBounds(MGLCoordinateBounds.fromArray(bounds), edgePadding: UIEdgeInsets.init(top: paddingTop, left: paddingLeft, bottom: paddingBottom, right: paddingRight))
         case "newLatLngZoom":
             guard let coordinate = cameraUpdate[1] as? [Double] else { return nil }
             guard let zoom = cameraUpdate[2] as? Double else { return nil }

--- a/mapbox_gl_platform_interface/lib/src/camera.dart
+++ b/mapbox_gl_platform_interface/lib/src/camera.dart
@@ -108,17 +108,6 @@ class CameraUpdate {
     return CameraUpdate._(<dynamic>['newLatLng', latLng.toJson()]);
   }
 
-  /* /// Returns a camera update that transforms the camera so that the specified
-  /// geographical bounding box is centered in the map view at the greatest
-  /// possible zoom level. A non-zero [padding] insets the bounding box from the
-  /// map view's edges. The camera's new tilt and bearing will both be 0.0.
-  static CameraUpdate newLatLngBounds(LatLngBounds bounds, double padding) {
-    return CameraUpdate._(<dynamic>[
-      'newLatLngBounds',
-      bounds.toList(),
-      padding,
-    ]);
-  } */
 
   /// Returns a camera update that transforms the camera so that the specified
   /// geographical bounding box is centered in the map view at the greatest

--- a/mapbox_gl_platform_interface/lib/src/camera.dart
+++ b/mapbox_gl_platform_interface/lib/src/camera.dart
@@ -108,7 +108,7 @@ class CameraUpdate {
     return CameraUpdate._(<dynamic>['newLatLng', latLng.toJson()]);
   }
 
-  /// Returns a camera update that transforms the camera so that the specified
+  /* /// Returns a camera update that transforms the camera so that the specified
   /// geographical bounding box is centered in the map view at the greatest
   /// possible zoom level. A non-zero [padding] insets the bounding box from the
   /// map view's edges. The camera's new tilt and bearing will both be 0.0.
@@ -117,6 +117,23 @@ class CameraUpdate {
       'newLatLngBounds',
       bounds.toList(),
       padding,
+    ]);
+  } */
+
+  /// Returns a camera update that transforms the camera so that the specified
+  /// geographical bounding box is centered in the map view at the greatest
+  /// possible zoom level. A non-zero [left], [top], [right] and [bottom] padding
+  /// insets the bounding box from the map view's edges. 
+  /// The camera's new tilt and bearing will both be 0.0.
+  static CameraUpdate newLatLngBounds(LatLngBounds bounds,
+      {double left = 0, double top = 0, double right = 0, double bottom = 0}) {
+    return CameraUpdate._(<dynamic>[
+      'newLatLngBounds',
+      bounds.toList(),
+      left,
+      top,
+      right,
+      bottom,
     ]);
   }
 

--- a/mapbox_gl_web/lib/src/convert.dart
+++ b/mapbox_gl_web/lib/src/convert.dart
@@ -90,7 +90,10 @@ class Convert {
         );
       case 'newLatLngBounds':
         final bounds = json[1];
-        final padding = json[2];
+        final left = json[2];
+        final top = json[3];
+        final right = json[4];
+        final bottom = json[5];
         final camera = mapboxMap.cameraForBounds(
             LngLatBounds(
               LngLat(bounds[0][1], bounds[0][0]),
@@ -98,10 +101,10 @@ class Convert {
             ),
             {
               'padding': {
-                'top': padding,
-                'bottom': padding,
-                'left': padding,
-                'right': padding
+                'top': top,
+                'bottom': bottom,
+                'left': left,
+                'right': right,
               }
             });
         return camera;


### PR DESCRIPTION
Split the padding value into separate left, top, right and bottom padding values in CameraUpdate.newLatLngBounds(). 
This is a breaking change and has been noted as such in the changelog.

Closes #304.