### PR TITLE
Re-enable attribution dialog on android

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -22,7 +22,7 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   public final String TAG = getClass().getSimpleName();
   private final MapboxMapOptions options = new MapboxMapOptions()
     .textureMode(true)
-    .attributionEnabled(false);
+    .attributionEnabled(true);
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
   private int myLocationTrackingMode = 0;


### PR DESCRIPTION
The attribution dialog was disabled in #12 because it caused the app to crash. It seems that the underlying issue has been fixed in flutter's platform view. I can successfully use the attribution dialog without any issues or crashes on my physical device as well as on the emulator.
Closes #13.

@tobrun Do you think we can safely re-enable this?