### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 We welcome contributions to this repository. Please follow these steps if you're interested in making contributions:
 
 1. Please familiarize yourself with the [process of running the example app](https://github.com/tobrun/flutter-mapbox-gl#running-the-example-app) and [add a Mapbox access token](https://github.com/tobrun/flutter-mapbox-gl#adding-a-mapbox-access-token) as described in the Readme. 
-2. Ensure that existing [pull requests](https://github.com/mapbox/flutter-mapbox-gl/pulls) and [issues](https://github.com/mapbox/flutter-mapbox-gl/issues) don’t already cover your contribution or question.
+2. Ensure that existing [pull requests](https://github.com/tobrun/flutter-mapbox-gl/pulls) and [issues](https://github.com/tobrun/flutter-mapbox-gl/issues) don’t already cover your contribution or question.
 
 3. Create a new branch that will contain your contributed code. Along with your contribution you should also adapt the example app to showcase any new features or APIs you have developed. This also makes testing your contribution much easier. Eventually create a pull request once you're done making changes.
 
-4. If there are any changes that developers should be aware of, please update the [changelog](https://github.com/mapbox/flutter-mapbox-gl/blob/master/CHANGELOG.md) once your pull request has been merged to the `master` branch.
+4. If there are any changes that developers should be aware of, please update the [changelog](https://github.com/tobrun/flutter-mapbox-gl/blob/master/CHANGELOG.md) once your pull request has been merged to the `master` branch.
 
 # Code of conduct
 Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).


### PR DESCRIPTION
While looking at the contributing guide I noticed some of the URLs still referenced the previous (now archived) `mapbox/flutter-mapbox-gl` project. Figured I might as well fix that as a first contribution!