### PR TITLE
Improved Image Source Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ The **recommended** way to provide your access token is through the `MapboxMap` 
 
 An alternative method to provide access tokens that was required until the v0.7 release is described in [this wiki article](https://github.com/tobrun/flutter-mapbox-gl/wiki/Mapbox-access-tokens).
 
+## Avoid Android UnsatisfiedLinkError
+
+Update buildTypes in `android\app\build.gradle`
+
+```gradle
+buildTypes {
+    release {
+        // other configs
+        ndk {
+            abiFilters 'armeabi-v7a','arm64-v8a','x86_64'
+        }
+    }
+}
+```
+
 ## Using the SDK in your project
 
 This project is available on [pub.dev](https://pub.dev/packages/mapbox_gl), follow the [instructions](https://flutter.dev/docs/development/packages-and-plugins/using-packages#adding-a-package-dependency-to-an-app) to integrate a package into your flutter application. For platform specific integration, use the flutter application under the example folder as reference. 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ buildTypes {
     release {
         // other configs
         ndk {
-            abiFilters 'armeabi-v7a','arm64-v8a','x86_64'
+            abiFilters 'armeabi-v7a','arm64-v8a','x86_64', 'x86'
         }
     }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -849,7 +849,7 @@ final class MapboxMapController
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
         }
         List<LatLng> coordinates = Convert.toLatLngList(call.argument("coordinates"));
-        style.addSource(new ImageSource(call.argument("name"), new LatLngQuad(coordinates.get(0), coordinates.get(1), coordinates.get(2), coordinates.get(3)), BitmapFactory.decodeByteArray(call.argument("bytes"), 0, call.argument("length"))));
+        style.addSource(new ImageSource(call.argument("imageSourceId"), new LatLngQuad(coordinates.get(0), coordinates.get(1), coordinates.get(2), coordinates.get(3)), BitmapFactory.decodeByteArray(call.argument("bytes"), 0, call.argument("length"))));
         result.success(null);
         break;
       }
@@ -857,7 +857,7 @@ final class MapboxMapController
         if (style == null) {
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
         }
-        style.removeSource((String) call.argument("name"));
+        style.removeSource((String) call.argument("imageSourceId"));
         result.success(null);
         break;
       }
@@ -865,7 +865,7 @@ final class MapboxMapController
         if (style == null) {
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
         }
-        style.addLayer(new RasterLayer(call.argument("name"), call.argument("sourceId")));
+        style.addLayer(new RasterLayer(call.argument("imageLayerId"), call.argument("imageSourceId")));
         result.success(null);
         break;
       }
@@ -873,7 +873,7 @@ final class MapboxMapController
         if (style == null) {
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
         }
-        style.removeLayer((String) call.argument("name"));
+        style.removeLayer((String) call.argument("imageLayerId"));
         result.success(null);
         break;
       }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -869,6 +869,14 @@ final class MapboxMapController
         result.success(null);
         break;
       }
+      case "style#addLayerBelow": {
+        if (style == null) {
+          result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);
+        }
+        style.addLayerBelow(new RasterLayer(call.argument("imageLayerId"), call.argument("imageSourceId")), call.argument("belowLayerId"));
+        result.success(null);
+        break;
+      }
       case "style#removeLayer": {
         if (style == null) {
           result.error("STYLE IS NULL", "The style is null. Has onStyleLoaded() already been invoked?", null);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
 
             // To fix UnsatisfiedLinkError
             ndk {
-                abiFilters 'armeabi-v7a','arm64-v8a','x86_64'
+                abiFilters 'armeabi-v7a','arm64-v8a','x86_64', 'x86'
             }
         }
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -46,6 +46,11 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+
+            // To fix UnsatisfiedLinkError
+            ndk {
+                abiFilters 'armeabi-v7a','arm64-v8a','x86_64'
+            }
         }
     }
     compileOptions {

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -30,6 +30,9 @@ class PlaceSymbolBody extends StatefulWidget {
 
 class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   PlaceSymbolBodyState();
+  
+  static const SOURCE_ID = 'sydney_source';
+  static const LAYER_ID = 'sydney_layer';
 
   bool sourceAdded = false;
   MapboxMapController controller;
@@ -44,30 +47,31 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   }
 
   /// Adds an asset image as a source to the currently displayed style
-  Future<void> addImageSourceFromAsset(String name, String assetName) async {
+  Future<void> addImageSourceFromAsset(String imageSourceId, String assetName) async {
     final ByteData bytes = await rootBundle.load(assetName);
     final Uint8List list = bytes.buffer.asUint8List();
     return controller.addImageSource(
-        name,
-        list,
-        LatLngQuad(
-          bottomRight: const LatLng(-33.86264728692581, 151.19916915893555),
-          bottomLeft: const LatLng(-33.86264728692581, 151.2288236618042),
-          topLeft: const LatLng(-33.84322353475214, 151.2288236618042),
-          topRight: const LatLng(-33.84322353475214, 151.19916915893555),
-        ));
+      imageSourceId,
+      list,
+      const LatLngQuad(
+        bottomRight: LatLng(-33.86264728692581, 151.19916915893555),
+        bottomLeft: LatLng(-33.86264728692581, 151.2288236618042),
+        topLeft: LatLng(-33.84322353475214, 151.2288236618042),
+        topRight: LatLng(-33.84322353475214, 151.19916915893555),
+      ),
+    );
   }
 
-  Future<void> removeImageSource(String name){
-    return controller.removeImageSource(name);
+  Future<void> removeImageSource(String imageSourceId) {
+    return controller.removeImageSource(imageSourceId);
   }
 
-  Future<void> addLayer(String layerName, String sourceId) {
-    return controller.addLayer(layerName, sourceId);
+  Future<void> addLayer(String imageLayerId, String imageSourceId) {
+    return controller.addLayer(imageLayerId, imageSourceId);
   }
 
-  Future<void> removeLayer(String layerName) {
-    return controller.removeLayer(layerName);
+  Future<void> removeLayer(String imageLayerId) {
+    return controller.removeLayer(imageLayerId);
   }
 
   @override
@@ -101,22 +105,32 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                       children: <Widget>[
                         FlatButton(
                           child: const Text('Add source (asset image)'),
-                          onPressed: sourceAdded ? null : () => addImageSourceFromAsset("sydney", "assets/sydney.png").then((value) => setState(() => sourceAdded = true)),
+                          onPressed: sourceAdded
+                              ? null
+                              : () {
+                                  addImageSourceFromAsset(SOURCE_ID, 'assets/sydney.png').then((value) {
+                                    setState(() => sourceAdded = true);
+                                  });
+                                },
                         ),
                         FlatButton(
                           child: const Text('Remove source (asset image)'),
-                          onPressed: sourceAdded ? () async {
-                            await removeLayer("imageLayer");
-                            removeImageSource("sydney").then((value) => setState(() => sourceAdded = false));
-                          } : null,
+                          onPressed: sourceAdded
+                              ? () async {
+                                  await removeLayer(LAYER_ID);
+                                  removeImageSource(SOURCE_ID).then((value) {
+                                    setState(() => sourceAdded = false);
+                                  });
+                                }
+                              : null,
                         ),
                         FlatButton(
                           child: const Text('Show layer'),
-                          onPressed: sourceAdded ? () => addLayer("imageLayer", "sydney") : null,
+                          onPressed: sourceAdded ? () => addLayer(LAYER_ID, SOURCE_ID) : null,
                         ),
                         FlatButton(
                           child: const Text('Hide layer'),
-                          onPressed: sourceAdded ? () => removeLayer("imageLayer") : null,
+                          onPressed: sourceAdded ? () => removeLayer(LAYER_ID) : null,
                         ),
                       ],
                     ),

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -70,6 +70,10 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     return controller.addLayer(imageLayerId, imageSourceId);
   }
 
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) {
+    return controller.addLayerBelow(imageLayerId, imageSourceId, belowLayerId);
+  }
+
   Future<void> removeLayer(String imageLayerId) {
     return controller.removeLayer(imageLayerId);
   }
@@ -127,6 +131,10 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
                         FlatButton(
                           child: const Text('Show layer'),
                           onPressed: sourceAdded ? () => addLayer(LAYER_ID, SOURCE_ID) : null,
+                        ),
+                        FlatButton(
+                          child: const Text('Show layer below water'),
+                          onPressed: sourceAdded ? () => addLayerBelow(LAYER_ID, SOURCE_ID, 'water') : null,
                         ),
                         FlatButton(
                           child: const Text('Hide layer'),

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -588,6 +588,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
      *  MGLAnnotationControllerDelegate
      */
     func annotationController(_ annotationController: MGLAnnotationController, didSelect styleAnnotation: MGLStyleAnnotation) {
+        annotationController.deselectStyleAnnotation(styleAnnotation)
         guard let channel = channel else {
             return
         }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -461,7 +461,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             result(nil)
         case "style#addImageSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["name"] as? String else { return }
+            guard let name = arguments["imageSourceId"] as? String else { return }
             guard let bytes = arguments["bytes"] as? FlutterStandardTypedData else { return }
             guard let data = bytes.data as? Data else { return }
             guard let image = UIImage(data: data) else { return }
@@ -480,14 +480,14 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             result(nil)
         case "style#removeImageSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["name"] as? String else { return }
+            guard let name = arguments["imageSourceId"] as? String else { return }
             guard let source = self.mapView.style?.source(withIdentifier: name) else { return }
             self.mapView.style?.removeSource(source)
             result(nil)
         case "style#addLayer":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["name"] as? String else { return }
-            guard let sourceId = arguments["sourceId"] as? String else { return }
+            guard let name = arguments["imageLayerId"] as? String else { return }
+            guard let sourceId = arguments["imageSourceId"] as? String else { return }
             
             guard let source = self.mapView.style?.source(withIdentifier: sourceId) else { return }
             let layer = MGLRasterStyleLayer(identifier: name, source: source)
@@ -495,7 +495,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             result(nil)
         case "style#removeLayer":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["name"] as? String else { return }
+            guard let name = arguments["imageLayerId"] as? String else { return }
             guard let layer = self.mapView.style?.layer(withIdentifier: name) else { return }
             self.mapView.style?.removeLayer(layer)
             result(nil)

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -461,7 +461,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             result(nil)
         case "style#addImageSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["imageSourceId"] as? String else { return }
+            guard let imageSourceId = arguments["imageSourceId"] as? String else { return }
             guard let bytes = arguments["bytes"] as? FlutterStandardTypedData else { return }
             guard let data = bytes.data as? Data else { return }
             guard let image = UIImage(data: data) else { return }
@@ -474,29 +474,69 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 topRight: CLLocationCoordinate2D(latitude: coordinates[1][0], longitude: coordinates[1][1])
             )
             
-            let source = MGLImageSource(identifier: name, coordinateQuad: quad, image: image)
+            //Check for duplicateSource error
+            if (self.mapView.style?.source(withIdentifier:  imageSourceId) != nil) {
+                result(FlutterError(code: "duplicateSource", message: "Source with imageSourceId \(imageSourceId) already exists", details: "Can't add duplicate source with imageSourceId: \(imageSourceId)" ))
+                return
+            }
+            
+            let source = MGLImageSource(identifier: imageSourceId, coordinateQuad: quad, image: image)
             self.mapView.style?.addSource(source)
             
             result(nil)
         case "style#removeImageSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["imageSourceId"] as? String else { return }
-            guard let source = self.mapView.style?.source(withIdentifier: name) else { return }
+            guard let imageSourceId = arguments["imageSourceId"] as? String else { return }
+            guard let source = self.mapView.style?.source(withIdentifier: imageSourceId) else { return }
             self.mapView.style?.removeSource(source)
             result(nil)
         case "style#addLayer":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["imageLayerId"] as? String else { return }
-            guard let sourceId = arguments["imageSourceId"] as? String else { return }
+            guard let imageLayerId = arguments["imageLayerId"] as? String else { return }
+            guard let imageSourceId = arguments["imageSourceId"] as? String else { return }
             
-            guard let source = self.mapView.style?.source(withIdentifier: sourceId) else { return }
-            let layer = MGLRasterStyleLayer(identifier: name, source: source)
+            //Check for duplicateLayer error
+            if (self.mapView.style?.layer(withIdentifier: imageLayerId)) != nil {
+                result(FlutterError(code: "duplicateLayer", message: "Layer already exists", details: "Can't add duplicate layer with imageLayerId: \(imageLayerId)" ))
+                return
+            }
+            //Check for noSuchSource error
+            guard let source = self.mapView.style?.source(withIdentifier: imageSourceId) else {
+                result(FlutterError(code: "noSuchSource", message: "No source found with imageSourceId \(imageSourceId)", details: "Can't add add layer for imageSourceId \(imageLayerId), as the source does not exist." ))
+                return
+            }
+            
+            let layer = MGLRasterStyleLayer(identifier: imageLayerId, source: source)
             self.mapView.style?.addLayer(layer)
+            result(nil)
+        case "style#addLayerBelow":
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let imageLayerId = arguments["imageLayerId"] as? String else { return }
+            guard let imageSourceId = arguments["imageSourceId"] as? String else { return }
+            guard let belowLayerId = arguments["belowLayerId"] as? String else { return }
+            
+            //Check for duplicateLayer error
+            if (self.mapView.style?.layer(withIdentifier: imageLayerId)) != nil {
+                result(FlutterError(code: "duplicateLayer", message: "Layer already exists", details: "Can't add duplicate layer with imageLayerId: \(imageLayerId)" ))
+                return
+            }
+            //Check for noSuchSource error
+            guard let source = self.mapView.style?.source(withIdentifier: imageSourceId) else {
+                result(FlutterError(code: "noSuchSource", message: "No source found with imageSourceId \(imageSourceId)", details: "Can't add add layer for imageSourceId \(imageLayerId), as the source does not exist." ))
+                return
+            }
+            //Check for noSuchLayer error
+            guard let belowLayer = self.mapView.style?.layer(withIdentifier: belowLayerId) else {
+                result(FlutterError(code: "noSuchLayer", message: "No layer found with layerId \(belowLayerId)", details: "Can't insert layer below layer with id \(belowLayerId), as no such layer exists." ))
+                return
+            }
+            let layer = MGLRasterStyleLayer(identifier: imageLayerId, source: source)
+            self.mapView.style?.insertLayer(layer, below: belowLayer)
             result(nil)
         case "style#removeLayer":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let name = arguments["imageLayerId"] as? String else { return }
-            guard let layer = self.mapView.style?.layer(withIdentifier: name) else { return }
+            guard let imageLayerId = arguments["imageLayerId"] as? String else { return }
+            guard let layer = self.mapView.style?.layer(withIdentifier: imageLayerId) else { return }
             self.mapView.style?.removeLayer(layer)
             result(nil)
         default:

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -758,24 +758,24 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   /// Adds an image source to the style currently displayed in the map, so that it can later be referred to by the provided name.
-  Future<void> addImageSource(String name, Uint8List bytes, LatLngQuad coordinates) {
+  Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     return MapboxGlPlatform.getInstance(_id)
-        .addImageSource(name, bytes, coordinates);
+        .addImageSource(imageSourceId, bytes, coordinates);
   }
 
   /// Removes previously added image source by name
-  Future<void> removeImageSource(String name) {
-    return MapboxGlPlatform.getInstance(_id).removeImageSource(name);
+  Future<void> removeImageSource(String imageSourceId) {
+    return MapboxGlPlatform.getInstance(_id).removeImageSource(imageSourceId);
   }
 
   /// Adds layer with name
-  Future<void> addLayer(String name, String sourceId) {
-    return MapboxGlPlatform.getInstance(_id).addLayer(name, sourceId);
+  Future<void> addLayer(String imageLayerId, String imageSourceId) {
+    return MapboxGlPlatform.getInstance(_id).addLayer(imageLayerId, imageSourceId);
   }
 
   /// Removes layer by name
-  Future<void> removeLayer(String name) {
-    return MapboxGlPlatform.getInstance(_id).removeLayer(name);
+  Future<void> removeLayer(String imageLayerId) {
+    return MapboxGlPlatform.getInstance(_id).removeLayer(imageLayerId);
   }
 
   /// Returns the point on the screen that corresponds to a geographical coordinate ([latLng]). The screen location is in screen pixels (not display pixels) relative to the top left of the map (not of the whole screen)

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -757,23 +757,23 @@ class MapboxMapController extends ChangeNotifier {
         .setSymbolTextIgnorePlacement(enable);
   }
 
-  /// Adds an image source to the style currently displayed in the map, so that it can later be referred to by the provided name.
+  /// Adds an image source to the style currently displayed in the map, so that it can later be referred to by the provided id.
   Future<void> addImageSource(String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
     return MapboxGlPlatform.getInstance(_id)
         .addImageSource(imageSourceId, bytes, coordinates);
   }
 
-  /// Removes previously added image source by name
+  /// Removes previously added image source by id
   Future<void> removeImageSource(String imageSourceId) {
     return MapboxGlPlatform.getInstance(_id).removeImageSource(imageSourceId);
   }
 
-  /// Adds layer with name
+  /// Adds layer with id
   Future<void> addLayer(String imageLayerId, String imageSourceId) {
     return MapboxGlPlatform.getInstance(_id).addLayer(imageLayerId, imageSourceId);
   }
 
-  /// Removes layer by name
+  /// Removes layer by id
   Future<void> removeLayer(String imageLayerId) {
     return MapboxGlPlatform.getInstance(_id).removeLayer(imageLayerId);
   }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -768,12 +768,17 @@ class MapboxMapController extends ChangeNotifier {
     return MapboxGlPlatform.getInstance(_id).removeImageSource(imageSourceId);
   }
 
-  /// Adds layer with id
+  /// Adds a Mapbox style layer to the map's style at render time.
   Future<void> addLayer(String imageLayerId, String imageSourceId) {
     return MapboxGlPlatform.getInstance(_id).addLayer(imageLayerId, imageSourceId);
   }
 
-  /// Removes layer by id
+  /// Adds a Mapbox style layer below the layer provided with belowLayerId to the map's style at render time,
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) {
+    return MapboxGlPlatform.getInstance(_id).addLayerBelow(imageLayerId, imageSourceId, belowLayerId);
+  }
+
+  /// Removes a Mapbox style layer
   Future<void> removeLayer(String imageLayerId) {
     return MapboxGlPlatform.getInstance(_id).removeLayer(imageLayerId);
   }

--- a/mapbox_gl_platform_interface/lib/src/location.dart
+++ b/mapbox_gl_platform_interface/lib/src/location.dart
@@ -107,7 +107,7 @@ class LatLngBounds {
 /// A geographical area representing a non-aligned quadrilateral
 /// This class does not wrap values to the world bounds
 class LatLngQuad {
-  LatLngQuad({@required this.topLeft, @required this.topRight, @required this.bottomRight, @required this.bottomLeft})
+  const LatLngQuad({@required this.topLeft, @required this.topRight, @required this.bottomRight, @required this.bottomLeft})
       : assert(topLeft != null),
         assert(topRight != null),
         assert(bottomRight != null),

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -241,6 +241,10 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('addLayer() has not been implemented.');
   }
 
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) async {
+    throw UnimplementedError('addLayerBelow() has not been implemented.');
+  }
+
   Future<void> removeLayer(String imageLayerId) async {
     throw UnimplementedError('removeLayer() has not been implemented.');
   }

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -228,20 +228,20 @@ abstract class MapboxGlPlatform {
         'setSymbolTextIgnorePlacement() has not been implemented.');
   }
 
-  Future<void> addImageSource(String name, Uint8List bytes,
+  Future<void> addImageSource(String imageSourceId, Uint8List bytes,
       LatLngQuad coordinates) async {
     throw UnimplementedError('addImageSource() has not been implemented.');
   }
 
-  Future<void> removeImageSource(String name) async {
+  Future<void> removeImageSource(String imageSourceId) async {
     throw UnimplementedError('removeImageSource() has not been implemented.');
   }
 
-  Future<void> addLayer(String name, String sourceId) async {
+  Future<void> addLayer(String imageLayerId, String imageSourceId) async {
     throw UnimplementedError('addLayer() has not been implemented.');
   }
 
-  Future<void> removeLayer(String name) async {
+  Future<void> removeLayer(String imageLayerId) async {
     throw UnimplementedError('removeLayer() has not been implemented.');
   }
 

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -404,11 +404,11 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       final Map<Object, Object> reply = await _channel.invokeMethod(
           'locationComponent#getLastLocation', null);
       double latitude = 0.0, longitude = 0.0;
-      if (reply.containsKey("latitude") && reply["latitude"] != null) {
-        latitude = double.parse(reply["latitude"].toString());
+      if (reply.containsKey('latitude') && reply['latitude'] != null) {
+        latitude = double.parse(reply['latitude'].toString());
       }
-      if (reply.containsKey("longitude") && reply["longitude"] != null) {
-        longitude = double.parse(reply["longitude"].toString());
+      if (reply.containsKey('longitude') && reply['longitude'] != null) {
+        longitude = double.parse(reply['longitude'].toString());
       }
       return LatLng(latitude, longitude);
     } on PlatformException catch (e) {
@@ -422,12 +422,12 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       final Map<Object, Object> reply =
           await _channel.invokeMethod('map#getVisibleRegion', null);
       LatLng southwest, northeast;
-      if (reply.containsKey("sw")) {
-        List<dynamic> coordinates = reply["sw"];
+      if (reply.containsKey('sw')) {
+        List<dynamic> coordinates = reply['sw'];
         southwest = LatLng(coordinates[0], coordinates[1]);
       }
-      if (reply.containsKey("ne")) {
-        List<dynamic> coordinates = reply["ne"];
+      if (reply.containsKey('ne')) {
+        List<dynamic> coordinates = reply['ne'];
         northeast = LatLng(coordinates[0], coordinates[1]);
       }
       return LatLngBounds(southwest: southwest, northeast: northeast);
@@ -441,10 +441,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       [bool sdf = false]) async {
     try {
       return await _channel.invokeMethod('style#addImage', <String, Object>{
-        "name": name,
-        "bytes": bytes,
-        "length": bytes.length,
-        "sdf": sdf
+        'name': name,
+        'bytes': bytes,
+        'length': bytes.length,
+        'sdf': sdf
       });
     } on PlatformException catch (e) {
       return new Future.error(e);
@@ -500,14 +500,14 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
-  Future<void> addImageSource(String name, Uint8List bytes,
+  Future<void> addImageSource(String imageSourceId, Uint8List bytes,
       LatLngQuad coordinates) async {
     try {
       return await _channel.invokeMethod('style#addImageSource', <String, Object>{
-        "name": name,
-        "bytes": bytes,
-        "length": bytes.length,
-        "coordinates": coordinates.toList()
+        'imageSourceId': imageSourceId,
+        'bytes': bytes,
+        'length': bytes.length,
+        'coordinates': coordinates.toList()
       });
     } on PlatformException catch (e) {
       return new Future.error(e);
@@ -529,10 +529,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
-  Future<void> removeImageSource(String name) async {
+  Future<void> removeImageSource(String imageSourceId) async {
     try {
       return await _channel.invokeMethod('style#removeImageSource', <String, Object>{
-        "name": name
+        'imageSourceId': imageSourceId
       });
     } on PlatformException catch (e) {
       return new Future.error(e);
@@ -540,11 +540,11 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
   
   @override
-  Future<void> addLayer(String name, String sourceId) async {
+  Future<void> addLayer(String imageLayerId, String imageSourceId) async {
     try {
       return await _channel.invokeMethod('style#addLayer', <String, Object>{
-        "name": name,
-        "sourceId": sourceId
+        'imageLayerId': imageLayerId,
+        'imageSourceId': imageSourceId
       });
     } on PlatformException catch (e) {
       return new Future.error(e);
@@ -552,10 +552,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
   
   @override
-  Future<void> removeLayer(String name) async {
+  Future<void> removeLayer(String imageLayerId) async {
     try {
       return await _channel.invokeMethod('style#removeLayer', <String, Object>{
-        "name": name
+        'imageLayerId': imageLayerId
       });
     } on PlatformException catch (e) {
       return new Future.error(e);

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -550,6 +550,19 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       return new Future.error(e);
     }
   }
+
+  @override
+  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) async {
+    try {
+      return await _channel.invokeMethod('style#addLayerBelow', <String, Object>{
+        'imageLayerId': imageLayerId,
+        'imageSourceId': imageSourceId,
+        'belowLayerId': belowLayerId
+      });
+    } on PlatformException catch (e) {
+      return new Future.error(e);
+    }
+  }
   
   @override
   Future<void> removeLayer(String imageLayerId) async {


### PR DESCRIPTION
My previous PR for adding basic image source support got merged, and while functional, I think it was lacking some consistency. This PR is a continuation of that work, it:
- Is more explicit about the parameters, instead of using the generic `name` it's now either `imageSourceId` or `imageLayerId`. 
- Adds `addLayerBelow` functionality. In my use case I had to insert layers below the markers, this can be done using this functions and e.g. adding the source below the `country-label` layer.
- Does some sanity checks on iOS before adding sources/layers
- Updated the `PlaceSource` sample to more clearly demonstrate the difference between the ImageSource and ImageLayer and to add a demo of the `addLayerBelow` functionality.
- Fixed some coding style consistency issues where double quotes where used instead of flutter preferred single quotes

note: it's built on top of the UnsatisfiedLinkError branch as without those changes I could not get the sample project to run anymore.

`addLayerBelow` demo:

![mapboxdemo](https://user-images.githubusercontent.com/2759651/100595296-04953700-32fb-11eb-8359-ff9eb4aca62e.gif)
