### PR TITLE
Avoid white space when resizing map on web

### DIFF
--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -32,11 +32,12 @@ class FullMapState extends State<FullMap> {
   Widget build(BuildContext context) {
     return new Scaffold(
         body: MapboxMap(
-          accessToken: MapsDemo.ACCESS_TOKEN,
-          onMapCreated: _onMapCreated,
-          initialCameraPosition:
-          const CameraPosition(target: LatLng(0.0, 0.0)),
-        )
-    );
+      accessToken: MapsDemo.ACCESS_TOKEN,
+      onMapCreated: _onMapCreated,
+      initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+      onStyleLoadedCallback: onStyleLoadedCallback,
+    ));
   }
+
+  void onStyleLoadedCallback() {}
 }

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -341,6 +341,19 @@ class MapboxMapController extends MapboxGlPlatform
     _map.on('movestart', _onCameraMoveStarted);
     _map.on('move', _onCameraMove);
     _map.on('moveend', _onCameraIdle);
+    _map.on('resize', _onMapResize);
+  }
+
+  void _onMapResize(Event e) {
+    Timer(Duration(microseconds: 10), () {
+      var container = _map.getContainer();
+      var canvas = _map.getCanvas();
+      var widthMismatch = canvas.clientWidth != container.clientWidth;
+      var heightMismatch = canvas.clientHeight != container.clientHeight;
+      if (widthMismatch || heightMismatch) {
+        _map.resize();
+      }
+    });
   }
 
   void _onMapClick(e) {


### PR DESCRIPTION
When resizing the browser screen Flutter fires several resize events.
These events are properly propagated to the containing div, but not
always handled by the map. It appears Mapbox misses the last resize event.
Therefore, we fire a timer that will check for mismatching width/height
between mapbox and it's container and trigger an additional resizing.

To reproduce: Open example/FullMapPage and resize the window fast,
e.g. by mouse or by maximising the window. When increasing the window
size the right/bottom area of the map will stay white.

The issue can be easily reproduced in Safari and Chrome.