### PR TITLE
Activate CameraTargetBounds In Android

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -28,6 +28,7 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
   private String styleString = Style.MAPBOX_STREETS;
+  private LatLngBounds bounds = null;
 
   MapboxMapController build(
     int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar, String accessToken) {
@@ -38,6 +39,8 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
     controller.setMyLocationTrackingMode(myLocationTrackingMode);
     controller.setMyLocationRenderMode(myLocationRenderMode);
     controller.setTrackCameraPosition(trackCameraPosition);
+    if(null != bounds)
+      controller.setCameraTargetBounds(bounds);
     return controller;
   }
 
@@ -52,7 +55,8 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
 
   @Override
   public void setCameraTargetBounds(LatLngBounds bounds) {
-    Log.e(TAG, "setCameraTargetBounds is supported only after map initiated.");
+    this.bounds = bounds;
+//    Log.e(TAG, "setCameraTargetBounds is supported only after map initiated.");
     //throw new UnsupportedOperationException("setCameraTargetBounds is supported only after map initiated.");
     //options.latLngBoundsForCameraTarget(bounds);
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -141,6 +141,7 @@ final class MapboxMapController
   private LocationEngineCallback<LocationEngineResult> locationEngineCallback = null;
   private LocalizationPlugin localizationPlugin;
   private Style style;
+  private LatLngBounds bounds = null;
 
   MapboxMapController(
     int id,
@@ -329,6 +330,9 @@ final class MapboxMapController
 
     setStyleString(styleStringInitial);
     // updateMyLocationEnabled();
+
+    if(null != bounds)
+      mapboxMap.setLatLngBoundsForCameraTarget(bounds);
   }
 
   @Override
@@ -1095,7 +1099,8 @@ final class MapboxMapController
 
   @Override
   public void setCameraTargetBounds(LatLngBounds bounds) {
-    mapboxMap.setLatLngBoundsForCameraTarget(bounds);
+    this.bounds = bounds;
+//    mapboxMap.setLatLngBoundsForCameraTarget(bounds);
   }
 
   @Override


### PR DESCRIPTION
In Android after setting CameraTargetBounds you will catch exception "setCameraTargetBounds is supported only after map initiated" and there is no other places for set it. Now this setting works.