### PR TITLE
[android] migrate to new Android flutter plugin architecture

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.Style;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,9 +31,9 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private String styleString = Style.MAPBOX_STREETS;
 
   MapboxMapController build(
-    int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar, String accessToken) {
+    int id, Context context, BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider, String accessToken) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context, state, registrar, options, accessToken, styleString);
+      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -1,27 +1,25 @@
 package com.mapbox.mapboxgl;
 
-import static io.flutter.plugin.common.PluginRegistry.Registrar;
-
 import android.content.Context;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 
+import java.util.Map;
+
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
 
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class MapboxMapFactory extends PlatformViewFactory {
 
-  private final AtomicInteger mActivityState;
-  private final Registrar mPluginRegistrar;
+  private final BinaryMessenger messenger;
+  private final MapboxMapsPlugin.LifecycleProvider lifecycleProvider;
 
-  public MapboxMapFactory(AtomicInteger state, Registrar registrar) {
+  public MapboxMapFactory(BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider) {
     super(StandardMessageCodec.INSTANCE);
-    mActivityState = state;
-    mPluginRegistrar = registrar;
+    this.messenger = messenger;
+    this.lifecycleProvider = lifecycleProvider;
   }
 
   @Override
@@ -34,6 +32,6 @@ public class MapboxMapFactory extends PlatformViewFactory {
       CameraPosition position = Convert.toCameraPosition(params.get("initialCameraPosition"));
       builder.setInitialCameraPosition(position);
     }
-    return builder.build(id, context, mActivityState, mPluginRegistrar, (String) params.get("accessToken"));
+    return builder.build(id, context, messenger, lifecycleProvider, (String) params.get("accessToken"));
   }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
@@ -8,8 +8,16 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
 
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
@@ -19,87 +27,195 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
  * the map. A Texture drawn using MapboxMap bitmap snapshots can then be shown instead of the
  * overlay.
  */
-public class MapboxMapsPlugin implements Application.ActivityLifecycleCallbacks {
-  static final int CREATED = 1;
-  static final int STARTED = 2;
-  static final int RESUMED = 3;
-  static final int PAUSED = 4;
-  static final int STOPPED = 5;
-  static final int DESTROYED = 6;
-  private final AtomicInteger state = new AtomicInteger(0);
-  private final int registrarActivityHashCode;
+public class MapboxMapsPlugin implements FlutterPlugin, ActivityAware {
+
+  private static final String VIEW_TYPE = "plugins.flutter.io/mapbox_gl";
+
+  static FlutterAssets flutterAssets;
+  private Lifecycle lifecycle;
+
+  public MapboxMapsPlugin() {
+    // no-op
+  }
+
+  // New Plugin APIs
+
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    flutterAssets = binding.getFlutterAssets();
+
+    MethodChannel methodChannel = new MethodChannel(binding.getBinaryMessenger(), "plugins.flutter.io/mapbox_gl");
+    methodChannel.setMethodCallHandler(
+      new GlobalMethodHandler(
+        binding.getApplicationContext(),
+        binding.getFlutterAssets()
+      )
+    );
+
+    binding
+      .getPlatformViewRegistry()
+      .registerViewFactory(
+        "plugins.flutter.io/mapbox_gl", new MapboxMapFactory(binding.getBinaryMessenger(), new LifecycleProvider() {
+          @Nullable
+          @Override
+          public Lifecycle getLifecycle() {
+            return lifecycle;
+          }
+        }));
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    // no-op
+  }
+
+  @Override
+  public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding);
+  }
+
+  @Override
+  public void onDetachedFromActivityForConfigChanges() {
+    onDetachedFromActivity();
+  }
+
+  @Override
+  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+    onAttachedToActivity(binding);
+  }
+
+  @Override
+  public void onDetachedFromActivity() {
+    lifecycle = null;
+  }
+
+  // Old Plugin APIs
 
   public static void registerWith(Registrar registrar) {
-    if (registrar.activity() == null) {
+    final Activity activity = registrar.activity();
+    if (activity == null) {
       // When a background flutter view tries to register the plugin, the registrar has no activity.
       // We stop the registration process as this plugin is foreground only.
       return;
     }
-    final MapboxMapsPlugin plugin = new MapboxMapsPlugin(registrar);
-    registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
-    registrar
-      .platformViewRegistry()
-      .registerViewFactory(
-        "plugins.flutter.io/mapbox_gl", new MapboxMapFactory(plugin.state, registrar));
+    if (activity instanceof LifecycleOwner) {
+      registrar
+        .platformViewRegistry()
+        .registerViewFactory(
+          VIEW_TYPE,
+          new MapboxMapFactory(
+            registrar.messenger(),
+            new LifecycleProvider() {
+              @Override
+              public Lifecycle getLifecycle() {
+                return ((LifecycleOwner) activity).getLifecycle();
+              }
+            }));
+    } else {
+      registrar
+        .platformViewRegistry()
+        .registerViewFactory(
+          VIEW_TYPE,
+          new MapboxMapFactory(registrar.messenger(), new ProxyLifecycleProvider(activity)));
+    }
 
-    MethodChannel methodChannel =
-            new MethodChannel(registrar.messenger(), "plugins.flutter.io/mapbox_gl");
+    MethodChannel methodChannel = new MethodChannel(
+      registrar.messenger(),
+      "plugins.flutter.io/mapbox_gl"
+    );
     methodChannel.setMethodCallHandler(new GlobalMethodHandler(registrar));
   }
 
-  @Override
-  public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+  private static final class ProxyLifecycleProvider
+    implements Application.ActivityLifecycleCallbacks, LifecycleOwner, LifecycleProvider {
+
+    private final LifecycleRegistry lifecycle = new LifecycleRegistry(this);
+    private final int registrarActivityHashCode;
+
+    private ProxyLifecycleProvider(Activity activity) {
+      this.registrarActivityHashCode = activity.hashCode();
+      activity.getApplication().registerActivityLifecycleCallbacks(this);
     }
-    state.set(CREATED);
-  }
 
-  @Override
-  public void onActivityStarted(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
     }
-    state.set(STARTED);
-  }
 
-  @Override
-  public void onActivityResumed(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    @Override
+    public void onActivityStarted(Activity activity) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
     }
-    state.set(RESUMED);
-  }
 
-  @Override
-  public void onActivityPaused(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    @Override
+    public void onActivityResumed(Activity activity) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     }
-    state.set(PAUSED);
-  }
 
-  @Override
-  public void onActivityStopped(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    @Override
+    public void onActivityPaused(Activity activity) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     }
-    state.set(STOPPED);
-  }
 
-  @Override
-  public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-  }
-
-  @Override
-  public void onActivityDestroyed(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    @Override
+    public void onActivityStopped(Activity activity) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
     }
-    state.set(DESTROYED);
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+      if (activity.hashCode() != registrarActivityHashCode) {
+        return;
+      }
+      activity.getApplication().unregisterActivityLifecycleCallbacks(this);
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    }
+
+    @NonNull
+    @Override
+    public Lifecycle getLifecycle() {
+      return lifecycle;
+    }
   }
 
-  private MapboxMapsPlugin(Registrar registrar) {
-    this.registrarActivityHashCode = registrar.activity().hashCode();
+  interface LifecycleProvider {
+    @Nullable
+    Lifecycle getLifecycle();
+  }
+
+  /** Provides a static method for extracting lifecycle objects from Flutter plugin bindings. */
+  public static class FlutterLifecycleAdapter {
+
+    /**
+     * Returns the lifecycle object for the activity a plugin is bound to.
+     *
+     * <p>Returns null if the Flutter engine version does not include the lifecycle extraction code.
+     * (this probably means the Flutter engine version is too old).
+     */
+    @NonNull
+    public static Lifecycle getActivityLifecycle(
+      @NonNull ActivityPluginBinding activityPluginBinding) {
+      HiddenLifecycleReference reference =
+        (HiddenLifecycleReference) activityPluginBinding.getLifecycle();
+      return reference.getLifecycle();
+    }
   }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,22 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapbox.mapboxglexample">
 
-    <!-- The INTERNET permission is required for development. Specifically,
-         flutter needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="mapbox_gl_example"
         android:icon="@mipmap/ic_launcher">
+
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
@@ -24,10 +16,6 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
             <meta-data
                 android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
                 android:value="true" />
@@ -37,6 +25,17 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".EmbeddingV1Activity"
+            android:theme="@android:style/Theme.Black.NoTitleBar"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+        </activity>
+
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
 
     </application>
 </manifest>

--- a/example/android/app/src/main/java/com/mapbox/mapboxglexample/EmbeddingV1Activity.java
+++ b/example/android/app/src/main/java/com/mapbox/mapboxglexample/EmbeddingV1Activity.java
@@ -1,0 +1,16 @@
+package com.mapbox.mapboxglexample;
+
+import android.os.Bundle;
+
+import com.mapbox.mapboxgl.MapboxMapsPlugin;
+
+import io.flutter.app.FlutterActivity;
+
+public class EmbeddingV1Activity extends FlutterActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    MapboxMapsPlugin.registerWith(registrarFor("com.mapbox.mapboxgl.MapboxMapsPlugin"));
+  }
+}

--- a/example/android/app/src/main/java/com/mapbox/mapboxglexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/mapbox/mapboxglexample/MainActivity.java
@@ -1,13 +1,7 @@
 package com.mapbox.mapboxglexample;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
+
 }


### PR DESCRIPTION
Closes https://github.com/tobrun/flutter-mapbox-gl/issues/486

This PR migrates tot the new embedding API as documented [here](https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration). The main changes next to the outlined in previous link is using AndroidX LifeCycle integration for getting notified about Activity lifecycle changes vs manually and maintaining an own state of it. 
