### PR TITLE
[android] bump release to v9.6.0 and use SDK registry distribution 

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -18,6 +18,7 @@ jobs:
       run: cd example && flutter analyze
 
   build-android:
+    environment: ANDROID_CI_DOWNLOADS_TOKEN
     name: "Build Android apk"
     runs-on: ubuntu-latest
 
@@ -30,12 +31,13 @@ jobs:
     - run: flutter pub get
     - name: Build example APK
       run: cd example && flutter build apk
-      # We might want to add a flutter test step in the future, when there actually are tests for this plugin
-        
+      env:
+        SDK_REGISTRY_TOKEN: ${{ secrets.SDK_REGISTRY_ANDROID}}
+
   build-iOS:
     name: Build iOS package
     runs-on: macos-latest
-    
+
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -47,7 +49,7 @@ jobs:
         run: |
           cd ./example
           flutter build ios --release --no-codesign
-          
+
   build-web:
     name: "Build web"
     runs-on: ubuntu-latest

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,15 +8,29 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 
 rootProject.allprojects {
+    def token = System.getenv('SDK_REGISTRY_TOKEN')
+    if (token == null || token.empty) {
+        throw new Exception("SDK Registry token is null. See README.md for more information.")
+    }
     repositories {
         google()
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/releases/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                username = "mapbox"
+                password = token
+            }
+        }
     }
 }
 
@@ -37,7 +51,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     dependencies {
-        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.0"
+        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.0"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0"
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.7.0'


### PR DESCRIPTION
Updates to the latest gl-native release on Android and leverages SDK registry distribution. 