### PR TITLE
[offline][android] use region ids provided by MB + code cleanup

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxgl;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -42,13 +43,13 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
                 result.success(null);
                 break;
             case "downloadOfflineRegion":
-                //Get download region arguments from caller
+                // Get download region arguments from caller
                 OfflineRegionData regionData = new Gson().fromJson(methodCall.argument("region").toString(), OfflineRegionData.class);
-                //Prepare channel
+                // Prepare channel
                 String channelName = methodCall.argument("channelName");
                 OfflineChannelHandlerImpl channelHandler = new OfflineChannelHandlerImpl(registrar.messenger(), channelName);
 
-                //Start downloading
+                // Start downloading
                 OfflineManagerUtils.downloadRegion(result, context, regionData, channelHandler);
                 break;
             case "getListOfRegions":

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -107,7 +107,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         }
     }
 
-    private static int copy(InputStream input, OutputStream output) throws IOException {
+    private static void copy(InputStream input, OutputStream output) throws IOException {
         final byte[] buffer = new byte[BUFFER_SIZE];
         final BufferedInputStream in = new BufferedInputStream(input, BUFFER_SIZE);
         final BufferedOutputStream out = new BufferedOutputStream(output, BUFFER_SIZE);

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -56,7 +56,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
                 OfflineManagerUtils.regionsList(result, context);
                 break;
             case "deleteOfflineRegion":
-                OfflineManagerUtils.deleteRegion(result, context, methodCall.argument("id"));
+                OfflineManagerUtils.deleteRegion(result, context, methodCall.<Number>argument("id").longValue());
                 break;
             default:
                 result.notImplemented();

--- a/android/src/main/java/com/mapbox/mapboxgl/models/OfflineRegionData.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/models/OfflineRegionData.java
@@ -8,6 +8,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.offline.OfflineRegion;
+import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 
 import java.util.ArrayList;
@@ -18,7 +20,7 @@ import java.util.Map;
 
 public class OfflineRegionData {
     @SerializedName("id")
-    private int id;
+    public long id;
     @SerializedName("bounds")
     private List<List<Double>> bounds;
     @SerializedName("metadata")
@@ -30,7 +32,7 @@ public class OfflineRegionData {
     @SerializedName("maxZoom")
     private double maxZoom;
 
-    public OfflineRegionData(int id, List<List<Double>> bounds, Map<String, Object> metadata, String mapStyleUrl, double minZoom, double maxZoom) {
+    public OfflineRegionData(long id, List<List<Double>> bounds, Map<String, Object> metadata, String mapStyleUrl, double minZoom, double maxZoom) {
         this.id = id;
         this.bounds = bounds;
         this.metadata = metadata;
@@ -39,7 +41,7 @@ public class OfflineRegionData {
         this.maxZoom = maxZoom;
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
@@ -66,22 +68,36 @@ public class OfflineRegionData {
         return maxZoom;
     }
 
-    @Nullable
-    public static OfflineRegionData fromOfflineRegion(OfflineTilePyramidRegionDefinition region, byte[] metadata) {
-        Gson gson = new Gson();
-        String json = new String(metadata);
-        Map<String, Object> map = new HashMap<>();
-        map = gson.fromJson(json, map.getClass());
-        if (!map.containsKey("id")) return null;
-        int id = ((Double) map.get("id")).intValue();
-        map.remove("id");
+    public byte[] prepareMetadata() {
+        return new Gson().toJson((metadata == null) ? new HashMap() : metadata).getBytes();
+    }
+
+    public OfflineRegionDefinition generateRegionDefinition(float pixelDensity) {
+        // Create a bounding box for the offline region
+        return new OfflineTilePyramidRegionDefinition(
+                getMapStyleUrl(),
+                getBounds(),
+                getMinZoom(),
+                getMaxZoom(),
+                pixelDensity);
+    }
+
+    public static OfflineRegionData fromOfflineRegion(OfflineRegion region) {
+        OfflineRegionDefinition definition = region.getDefinition();
+        byte[] metadataBytes = region.getMetadata();
+
+        Map<String, Object> metadata = new HashMap<>();
+        if (metadataBytes != null) {
+            metadata.putAll(new Gson().fromJson(new String(metadataBytes), metadata.getClass()));
+        }
+
         return new OfflineRegionData(
-                id,
-                getBoundsAsList(region.getBounds()),
-                map,
-                region.getStyleURL(),
-                region.getMinZoom(),
-                region.getMaxZoom()
+                region.getID(),
+                getBoundsAsList(definition.getBounds()),
+                metadata,
+                definition.getStyleURL(),
+                definition.getMinZoom(),
+                definition.getMaxZoom()
         );
     }
 

--- a/android/src/main/java/com/mapbox/mapboxgl/models/OfflineRegionData.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/models/OfflineRegionData.java
@@ -86,10 +86,11 @@ public class OfflineRegionData {
         OfflineRegionDefinition definition = region.getDefinition();
         byte[] metadataBytes = region.getMetadata();
 
-        Map<String, Object> metadata = new HashMap<>();
+        Map<String, Object> metadata = null;
         if (metadataBytes != null) {
-            metadata.putAll(new Gson().fromJson(new String(metadataBytes), metadata.getClass()));
+            metadata = new Gson().fromJson(new String(metadataBytes), HashMap.class);
         }
+        metadata = (metadata == null) ? new HashMap() : metadata;
 
         return new OfflineRegionData(
                 region.getID(),

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -43,7 +43,8 @@ Future<dynamic> downloadOfflineRegion(
   String accessToken,
   Function(DownloadRegionStatus event) onEvent,
 }) {
-  String channelName = 'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
+  String channelName =
+      'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
   final result =
       _globalChannel.invokeMethod('downloadOfflineRegion', <String, dynamic>{
@@ -52,51 +53,50 @@ Future<dynamic> downloadOfflineRegion(
     'region': json.encode(region._toJson())
   });
 
-if (onEvent != null) {
+  if (onEvent != null) {
+    EventChannel(channelName).receiveBroadcastStream().handleError((error) {
+      if (error is PlatformException) {
+        onEvent(Error(error));
+        return Error(error);
+      }
+      var unknownError = Error(
+        PlatformException(
+          code: 'UnknowException',
+          message:
+              'This error is unhandled by plugin. Please contact us if needed.',
+          details: error,
+        ),
+      );
+      onEvent(unknownError);
+      return unknownError;
+    }).listen((data) {
+      final Map<String, dynamic> jsonData = json.decode(data);
+      DownloadRegionStatus status;
+      switch (jsonData['status']) {
+        case 'start':
+          status = InProgress(0.0);
+          break;
+        case 'progress':
+          final dynamic value = jsonData['progress'];
+          double progress = 0.0;
 
-  EventChannel(channelName).receiveBroadcastStream().handleError((error) {
-    if (error is PlatformException) {
-      onEvent(Error(error));
-      return Error(error);
-    }
-    var unknownError = Error(
-      PlatformException(
-        code: 'UnknowException',
-        message:
-            'This error is unhandled by plugin. Please contact us if needed.',
-        details: error,
-      ),
-    );
-    onEvent(unknownError);
-    return unknownError;
-  }).listen((data) {
-    final Map<String, dynamic> jsonData = json.decode(data);
-    DownloadRegionStatus status;
-    switch (jsonData['status']) {
-      case 'start':
-        status = InProgress(0.0);
-        break;
-      case 'progress':
-        final dynamic value = jsonData['progress'];
-        double progress = 0.0;
+          if (value is int) {
+            progress = value.toDouble();
+          }
 
-        if (value is int) {
-          progress = value.toDouble();
-        }
+          if (value is double) {
+            progress = value;
+          }
 
-        if (value is double) {
-          progress = value;
-        }
-
-        status = InProgress(progress);
-        break;
-      case 'success':
-        status = Success();
-        break;
-    }
-    onEvent(status ?? (throw 'Invalid event status ${jsonData['status']}'));
-  });
-}
+          status = InProgress(progress);
+          break;
+        case 'success':
+          status = Success();
+          break;
+      }
+      onEvent(status ?? (throw 'Invalid event status ${jsonData['status']}'));
+    });
+  }
 
   return result;
 }


### PR DESCRIPTION
#336 was a great step forward for offline, but there's a lot that could be cleaned up IMO. Particularly, I want to implement `mergeOfflineRegions`, which is hard with the current design of assigning region ids, especially since one db file can contain multiple regions.

Current Changes (android only):
 - Merge `downloadOfflineRegion` and `downloadOfflineRegionStream`
   - change format of args from single json string to obj with `accessToken`,  `channelName`, and `region` keys (this will break iOS unless updated, but the change is simple)
 - Do not respect `id` passed into `downloadOfflineRegion` via `OfflineRegionData`, as it will be assigned by `createOfflineRegion`.
 - Do not store region id in `OfflineRegionData` metadata as this is unnecessary and misleading.
 - Perform `deleteOfflineRegion` based on ID given by mapbox at creation time rather than arbitrarily self-assigned id
 - Return `OfflineRegionData` result from the created `OfflineRegion` upon callback of `onCreate` in `createOfflineRegion` (needed to pass back ID to dart) instead of waiting for the download to finish, as there is already an event stream set up to take care of the download progress

Considered but not implemented mostly because of lack of iOS resources:
 - Restructure `OfflineRegionData`(native)/`OfflineRegion`(dart) classes into `OfflineRegionDefinition` and `OfflineRegion` classes to mirror SDK class structure. This is basically equivalient to something like `OfflineRegionOptions`.
 - Accept `OfflineRegionDefinition` as an arg to `downloadOfflineRegion`, and return `OfflineRegion` as a result