### PR TITLE
Fix: style annotation is not deselected

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -628,7 +628,13 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
      *  MGLAnnotationControllerDelegate
      */
     func annotationController(_ annotationController: MGLAnnotationController, didSelect styleAnnotation: MGLStyleAnnotation) {
-        annotationController.deselectStyleAnnotation(styleAnnotation)
+        DispatchQueue.main.async {
+            // Remove tint color overlay from selected annotation by
+            // deselecting. This is not handled correctly if requested
+            // synchronously from the callback.
+            annotationController.deselectStyleAnnotation(styleAnnotation)
+        }
+
         guard let channel = channel else {
             return
         }


### PR DESCRIPTION
When `deselectStyleAnnotation` is called synchronously in this delegate
callback, the operation silently fails and the selected appearance for
the annotation (typically, a blue tinted overlay) remains. This is an
unexpected state, since the flutter-mapbox-gl wrapper does not track
annotation selection and has no way to remove it. If the annotation
itself is removed, the selection remains visible on the map.

If we call `deselectStyleAnnotation` asynchronously, the selection is
removed as expected an is not visible to the user as a tinted overlay.