### PR TITLE
Support styleString as "Documents directory/Temporary directory" absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Map styles can be supplied by setting the `styleString` in the `MapOptions`. The
 
 1. Passing the URL of the map style. This can be one of the built-in map styles, also see `MapboxStyles` or a custom map style served remotely using a URL that start with 'http(s)://' or 'mapbox://'
 2. Passing the style as a local asset. Create a JSON file in the `assets` and add a reference in `pubspec.yml`. Set the style string to the relative path for this asset in order to load it into the map.
-3. Passing the raw JSON of the map style. This is only supported on Android.  
+3. Passing the style as a local file. create an JSON file in app directory (e.g. ApplicationDocumentsDirectory). Set the style string to the absolute path of this JSON file.
+4. Passing the raw JSON of the map style. This is only supported on Android.  
 
 ## Offline Sideloading
 

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -315,21 +315,23 @@ final class MapboxMapController
 
   @Override
   public void setStyleString(String styleString) {
-    //check if json, url or plain string:
+    // Check if json, url, absolute path or asset path:
     if (styleString == null || styleString.isEmpty()) {
       Log.e(TAG, "setStyleString - string empty or null");
     } else if (styleString.startsWith("{") || styleString.startsWith("[")) {
       mapboxMap.setStyle(new Style.Builder().fromJson(styleString), onStyleLoadedCallback);
+    } else if (styleString.startsWith("/")) {
+      // Absolute path
+      mapboxMap.setStyle(new Style.Builder().fromUri("file://" + styleString), onStyleLoadedCallback);
     } else if (
-      !styleString.startsWith("http://") && 
-      !styleString.startsWith("https://")&& 
+      !styleString.startsWith("http://") &&
+      !styleString.startsWith("https://")&&
       !styleString.startsWith("mapbox://")) {
       // We are assuming that the style will be loaded from an asset here.
-      AssetManager assetManager = registrar.context().getAssets();
       String key = registrar.lookupKeyForAsset(styleString);
       mapboxMap.setStyle(new Style.Builder().fromUri("asset://" + key), onStyleLoadedCallback);
     } else {
-      mapboxMap.setStyle(new Style.Builder().fromUrl(styleString), onStyleLoadedCallback);
+      mapboxMap.setStyle(new Style.Builder().fromUri(styleString), onStyleLoadedCallback);
     }
   }
 

--- a/example/lib/local_style.dart
+++ b/example/lib/local_style.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'main.dart';
+import 'page.dart';
+
+class LocalStylePage extends ExamplePage {
+  LocalStylePage()
+      : super(const Icon(Icons.map), 'Local style');
+
+  @override
+  Widget build(BuildContext context) {
+    return const LocalStyle();
+  }
+}
+
+class LocalStyle extends StatefulWidget {
+  const LocalStyle();
+
+  @override
+  State createState() => LocalStyleState();
+}
+
+class LocalStyleState extends State<LocalStyle> {
+  MapboxMapController mapController;
+  String styleAbsoluteFilePath;
+
+  @override
+  initState() {
+    super.initState();
+
+    getApplicationDocumentsDirectory().then((dir) async {
+      String documentDir = dir.path;
+      String stylesDir = '$documentDir/styles';
+      String styleJSON = '{"version":8,"name":"Basic","constants":{},"sources":{"mapillary":{"type":"vector","tiles":["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],"attribution":"<a href=\\"https://www.mapillary.com\\" target=\\"_blank\\">© Mapillary, CC BY</a>","maxzoom":14}},"sprite":"","glyphs":"","layers":[{"id":"background","type":"background","paint":{"background-color":"rgba(135, 149, 154, 1)"}},{"id":"water","type":"fill","source":"mapbox","source-layer":"water","paint":{"fill-color":"rgba(108, 148, 120, 1)"}}]}';
+
+      await new Directory(stylesDir).create(recursive: true);
+
+      File styleFile = new File('$stylesDir/style.json');
+
+      await styleFile.writeAsString(styleJSON);
+
+      setState(() {
+        styleAbsoluteFilePath = styleFile.path;
+      });
+    });
+  }
+
+
+  void _onMapCreated(MapboxMapController controller) {
+    mapController = controller;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (styleAbsoluteFilePath == null) {
+      return Scaffold(
+        body: Center(child: Text('Creating local style file...')),
+      );
+    }
+
+    return new Scaffold(
+      body: MapboxMap(
+        accessToken: MapsDemo.ACCESS_TOKEN,
+        styleString: styleAbsoluteFilePath,
+        onMapCreated: _onMapCreated,
+        initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
+        onStyleLoadedCallback: onStyleLoadedCallback,
+      )
+    );
+  }
+
+  void onStyleLoadedCallback() {}
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:mapbox_gl_example/offline_regions.dart';
 import 'animate_camera.dart';
 import 'full_map.dart';
 import 'line.dart';
+import 'local_style.dart';
 import 'map_ui.dart';
 import 'move_camera.dart';
 import 'page.dart';
@@ -28,6 +29,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   PlaceSymbolPage(),
   PlaceSourcePage(),
   LinePage(),
+  LocalStylePage(),
   PlaceCirclePage(),
   PlaceFillPage(),
   ScrollingMapPage(),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
   location: ^2.5.3
+  path_provider: ^1.6.27
   http:
 
 dependency_overrides:

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -805,12 +805,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         mapView.maximumZoomLevel = max
     }
     func setStyleString(styleString: String) {
-        // Check if json, url or plain string:
+        // Check if json, url, absolute path or asset path:
         if styleString.isEmpty {
             NSLog("setStyleString - string empty")
         } else if (styleString.hasPrefix("{") || styleString.hasPrefix("[")) {
             // Currently the iOS Mapbox SDK does not have a builder for json.
             NSLog("setStyleString - JSON style currently not supported")
+        } else if (styleString.hasPrefix("/")) {
+            // Absolute path
+            mapView.styleURL = URL(fileURLWithPath: styleString, isDirectory: false)
         } else if (
             !styleString.hasPrefix("http://") && 
             !styleString.hasPrefix("https://") && 
@@ -818,6 +821,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             // We are assuming that the style will be loaded from an asset here.
             let assetPath = registrar.lookupKey(forAsset: styleString)
             mapView.styleURL = URL(string: assetPath, relativeTo: Bundle.main.resourceURL)
+            
+            
         } else {
             mapView.styleURL = URL(string: styleString)
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
@@ -131,14 +131,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   xml:
     dependency: transitive
     description:
@@ -147,5 +147,5 @@ packages:
     source: hosted
     version: "4.5.1"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.13+hotfix.4 <2.0.0"


### PR DESCRIPTION
Hi,

This PR will enable support for using `app documents directory` or `temporary directory` as `styleString` parameter for both Android and iOS.

#### Use case:
Currently, for dynamic styles, **flutter-mapbox-gl** only support `styleString` as raw JSON string and this feature only work on Android, so we doesn't have any way to load dynamic styles on iOS device.

This PR will allow us to save raw JSON that we got from anywhere (API call, generated by code,...) to app storage at runtime and then able to pass their path as `styleString` parameter.

#### Sample code:
```dart
  ...
  @override
  initState() {
    super.initState();

    getApplicationDocumentsDirectory().then((dir) async {
      String documentDir = dir.path;
      String stylesDir = '$documentDir/styles';
      String styleJSON = '{...}'; // JSON string

      await new Directory(stylesDir).create(recursive: true);

      File styleFile = new File('$stylesDir/style.json');

      await styleFile.writeAsString(styleJSON);

      setState(() {
        styleAbsoluteFilePath = styleFile.path;
      });
    });
  }
  ...
  @override
  Widget build(BuildContext context) {
    if (styleAbsoluteFilePath == null) {
      return Scaffold(
        body: Center(child: Text('Loading local style file...')),
      );
    }

    return new Scaffold(
      body: MapboxMap(
       ...,
        styleString: styleAbsoluteFilePath,
       ...
      )
    );
  }
  ...
```

Tested on Android 9 simulator, Android 10 real device, and iOS 14.3 simulator.

Thanks for such a great library and sorry for my bad English 😄 
