### PR TITLE
Add heading to UserLocation and expose UserLocation type

### DIFF
--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -32,6 +32,19 @@ extension CLLocation {
     }
 }
 
+extension CLHeading {
+    func toDict() -> [String: Any]? {
+        return ["magneticHeading": self.magneticHeading,
+                "trueHeading": self.trueHeading,
+                "headingAccuracy": self.headingAccuracy,
+                "x": self.x,
+                "y": self.y,
+                "z": self.z,
+                "timestamp": Int(self.timestamp.timeIntervalSince1970 * 1000),
+        ]
+    }
+}
+
 extension CLLocationCoordinate2D {
     func toArray()  -> [Double] {
         return [self.latitude, self.longitude]

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -749,7 +749,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     func mapView(_ mapView: MGLMapView, didUpdate userLocation: MGLUserLocation?) {
         if let channel = channel, let userLocation = userLocation, let location = userLocation.location {
             channel.invokeMethod("map#onUserLocationUpdated", arguments: [
-                "userLocation": location.toDict()
+                "userLocation": location.toDict(),
+                "heading": userLocation.heading?.toDict()
             ]);
        }
    }

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -22,6 +22,7 @@ export 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart'
         LatLngQuad,
         CameraPosition,
         UserLocation,
+        UserHeading,
         CameraUpdate,
         ArgumentCallbacks,
         Symbol,

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -21,6 +21,7 @@ export 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart'
         LatLngBounds,
         LatLngQuad,
         CameraPosition,
+        UserLocation,
         CameraUpdate,
         ArgumentCallbacks,
         Symbol,
@@ -37,7 +38,6 @@ export 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart'
         LineOptions,
         Fill,
         FillOptions;
-
 
 part 'src/controller.dart';
 part 'src/mapbox_map.dart';

--- a/mapbox_gl_platform_interface/lib/src/location.dart
+++ b/mapbox_gl_platform_interface/lib/src/location.dart
@@ -180,6 +180,9 @@ class UserLocation {
   /// Time the user's location was observed
   final DateTime timestamp;
 
+  /// The heading of the user location, null if not available.
+  final UserHeading heading;
+
   const UserLocation(
       {@required this.position,
       @required this.altitude,
@@ -187,5 +190,45 @@ class UserLocation {
       @required this.speed,
       @required this.horizontalAccuracy,
       @required this.verticalAccuracy,
+      @required this.timestamp,
+      @required this.heading});
+}
+
+/// Type represents a geomagnetic value, measured in microteslas, relative to a
+/// device axis in three dimensional space.
+class UserHeading {
+  /// Represents the direction in degrees, where 0 degrees is magnetic North.
+  /// The direction is referenced from the top of the device regardless of
+  /// device orientation as well as the orientation of the user interface.
+  final double magneticHeading;
+
+  /// Represents the direction in degrees, where 0 degrees is true North. The
+  /// direction is referenced from the top of the device regardless of device
+  /// orientation as well as the orientation of the user interface
+  final double trueHeading;
+
+  /// Represents the maximum deviation of where the magnetic heading may differ
+  /// from the actual geomagnetic heading in degrees. A negative value indicates
+  /// an invalid heading.
+  final double headingAccuracy;
+
+  /// Returns a raw value for the geomagnetism measured in the x-axis.
+  final double x;
+
+  /// Returns a raw value for the geomagnetism measured in the y-axis.
+  final double y;
+
+  /// Returns a raw value for the geomagnetism measured in the z-axis.
+  final double z;
+
+  /// Returns a timestamp for when the magnetic heading was determined.
+  final DateTime timestamp;
+  const UserHeading(
+      {@required this.magneticHeading,
+      @required this.trueHeading,
+      @required this.headingAccuracy,
+      @required this.x,
+      @required this.y,
+      @required this.z,
       @required this.timestamp});
 }

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -78,6 +78,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         break;
       case 'map#onUserLocationUpdated':
         final dynamic userLocation = call.arguments['userLocation'];
+        final dynamic heading = call.arguments['heading'];
         if (onUserLocationUpdatedPlatform != null) {
           onUserLocationUpdatedPlatform(UserLocation(
               position: LatLng(userLocation['position'][0], userLocation['position'][1]),
@@ -86,8 +87,20 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
               speed: userLocation['speed'],
               horizontalAccuracy: userLocation['horizontalAccuracy'],
               verticalAccuracy: userLocation['verticalAccuracy'],
-              timestamp: DateTime.fromMillisecondsSinceEpoch(userLocation['timestamp'])
-          ));
+              heading: heading == null
+                  ? null
+                  : UserHeading(
+                      magneticHeading: heading['magneticHeading'],
+                      trueHeading: heading['trueHeading'],
+                      headingAccuracy: heading['headingAccuracy'],
+                      x: heading['x'],
+                      y: heading['y'],
+                      z: heading['x'],
+                      timestamp: DateTime.fromMillisecondsSinceEpoch(
+                          heading['timestamp']),
+                    ),
+              timestamp: DateTime.fromMillisecondsSinceEpoch(
+                  userLocation['timestamp'])));
         }
         break;
       default:

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -413,7 +413,7 @@ class MapboxMapController extends MapboxGlPlatform
     );
     _geolocateControl.on('geolocate', (e) {
       _myLastLocation = LatLng(e.coords.latitude, e.coords.longitude);
-      onUserLocationUpdatedPlatform(UserLocation(position: LatLng(e.coords.latitude, e.coords.longitude), altitude: e.coords.altitude, bearing: e.coords.heading, speed: e.coords.speed, horizontalAccuracy: e.coords.accuracy, verticalAccuracy: e.coords.altitudeAccuracy, timestamp: DateTime.fromMillisecondsSinceEpoch(e.timestamp)));
+      onUserLocationUpdatedPlatform(UserLocation(position: LatLng(e.coords.latitude, e.coords.longitude), altitude: e.coords.altitude, bearing: e.coords.heading, speed: e.coords.speed, horizontalAccuracy: e.coords.accuracy, verticalAccuracy: e.coords.altitudeAccuracy, heading: null, timestamp: DateTime.fromMillisecondsSinceEpoch(e.timestamp)));
     });
     _geolocateControl.on('trackuserlocationstart', (_) {
       _onCameraTrackingChanged(true);


### PR DESCRIPTION
While UserLocation includes a "bearing" (also called "course")
indicating the direction of travel, it does not expose the heading of
the device. Since this information is already provided in the `didUpdate
userLocation` delegate method, we can add it to the `UserLocation`
payload for a trivial cost at runtime.

Also exposes the existing UserLocation type so that client code may 
refer to it.