### PR TITLE
Define annotation order

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -63,6 +63,15 @@ class Convert {
     return builder.build();
   }
 
+  static List<String> toAnnotationOrder(Object o) {
+    final List<?> data = toList(o);
+    List<String> annotations = new ArrayList();
+    for (int index = 0; index < data.size(); index++) {
+      annotations.add(toString(data.get(index)));
+    }
+    return annotations;
+  }
+
   static boolean isScrollByCameraUpdate(Object o) {
     return toString(toList(o).get(0)).equals("scrollBy");
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -16,6 +16,8 @@ import com.mapbox.mapboxsdk.maps.Style;
 import io.flutter.plugin.common.PluginRegistry;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
+import java.util.ArrayList;
 
 
 class MapboxMapBuilder implements MapboxMapOptionsSink {
@@ -28,11 +30,12 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
   private String styleString = Style.MAPBOX_STREETS;
+  private List<String> annotationOrder = new ArrayList();
 
   MapboxMapController build(
     int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar, String accessToken) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context, state, registrar, options, accessToken, styleString);
+      new MapboxMapController(id, context, state, registrar, options, accessToken, styleString, annotationOrder);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);
@@ -169,5 +172,9 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
             (int) 0, //right
             (int) y, //bottom
     });
+  }
+
+  public void setAnnotationOrder(List<String> annotations) {
+    this.annotationOrder = annotations;
   }
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -344,7 +344,7 @@ final class MapboxMapController
       MapboxMapController.this.style = style;
       for(String annotationType : annotationOrder) {
         switch (annotationType) {
-          case "AnnotationType.polygone":
+          case "AnnotationType.fill":
             enableFillManager(style);
             break;
           case "AnnotationType.line":
@@ -357,7 +357,7 @@ final class MapboxMapController
             enableSymbolManager(style);
             break;
           default:
-            throw new IllegalArgumentException("Unknown annotation type: " + annotationType + ", must be either 'polygone', 'line', 'circle' or 'symbol'");
+            throw new IllegalArgumentException("Unknown annotation type: " + annotationType + ", must be either 'fill', 'line', 'circle' or 'symbol'");
         }
       }
       

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -12,6 +12,8 @@ import io.flutter.plugin.platform.PlatformViewFactory;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
+import java.util.ArrayList;
 
 public class MapboxMapFactory extends PlatformViewFactory {
 
@@ -33,6 +35,10 @@ public class MapboxMapFactory extends PlatformViewFactory {
     if (params.containsKey("initialCameraPosition")) {
       CameraPosition position = Convert.toCameraPosition(params.get("initialCameraPosition"));
       builder.setInitialCameraPosition(position);
+    }
+    if (params.containsKey("annotationOrder")) {
+      List<String> annotations = Convert.toAnnotationOrder(params.get("annotationOrder"));
+      builder.setAnnotationOrder(annotations);
     }
     return builder.build(id, context, mActivityState, mPluginRegistrar, (String) params.get("accessToken"));
   }

--- a/example/lib/annotation_order_maps.dart
+++ b/example/lib/annotation_order_maps.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+
+import 'main.dart';
+import 'page.dart';
+
+class AnnotationOrderPage extends ExamplePage {
+  AnnotationOrderPage()
+      : super(const Icon(Icons.layers), 'Annotation order maps');
+
+  @override
+  Widget build(BuildContext context) => AnnotationOrderBody();
+}
+
+class AnnotationOrderBody extends StatefulWidget {
+  AnnotationOrderBody();
+
+  @override
+  _AnnotationOrderBodyState createState() => _AnnotationOrderBodyState();
+}
+
+class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
+  MapboxMapController controllerOne;
+  MapboxMapController controllerTwo;
+
+  final LatLng center = const LatLng(36.580664, 32.5563837);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 0.0),
+            child: Column(
+              children: <Widget>[
+                const Padding(
+                  padding: EdgeInsets.only(bottom: 5.0),
+                  child: Text(
+                      'This map has polygones (fill) above all other anotations (default behavior)'),
+                ),
+                Center(
+                  child: SizedBox(
+                    width: 250.0,
+                    height: 250.0,
+                    child: MapboxMap(
+                      accessToken: MapsDemo.ACCESS_TOKEN,
+                      onMapCreated: onMapCreatedOne,
+                      onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
+                      initialCameraPosition: CameraPosition(
+                        target: center,
+                        zoom: 5.0,
+                      ),
+                      annotationOrder: const [
+                        AnnotationType.line,
+                        AnnotationType.symbol,
+                        AnnotationType.circle,
+                        AnnotationType.polygone,
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 0.0),
+            child: Column(
+              children: <Widget>[
+                const Padding(
+                  padding: EdgeInsets.only(bottom: 5.0, top: 5.0),
+                  child: Text(
+                      'This map has polygones (fill) under all other anotations'),
+                ),
+                Center(
+                  child: SizedBox(
+                    width: 250.0,
+                    height: 250.0,
+                    child: MapboxMap(
+                      accessToken: MapsDemo.ACCESS_TOKEN,
+                      onMapCreated: onMapCreatedTwo,
+                      onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
+                      initialCameraPosition: CameraPosition(
+                        target: center,
+                        zoom: 5.0,
+                      ),
+                      annotationOrder: const [
+                        AnnotationType.polygone,
+                        AnnotationType.line,
+                        AnnotationType.symbol,
+                        AnnotationType.circle,
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void onMapCreatedOne(MapboxMapController controller) {
+    this.controllerOne = controller;
+  }
+
+  void onMapCreatedTwo(MapboxMapController controller) {
+    this.controllerTwo = controller;
+  }
+
+  void onStyleLoaded(MapboxMapController controller) {
+    controller.addSymbol(
+      SymbolOptions(
+        geometry: LatLng(
+          center.latitude,
+          center.longitude,
+        ),
+        iconImage: "airport-15",
+      ),
+    );
+    controller.addLine(
+      LineOptions(
+        draggable: false,
+        lineColor: "#ff0000",
+        lineWidth: 7.0,
+        lineOpacity: 1,
+        geometry: [
+          LatLng(35.3649902, 32.0593003),
+          LatLng(34.9475098, 31.1187944),
+          LatLng(36.7108154, 30.7040582),
+          LatLng(37.6995850, 33.6512083),
+          LatLng(35.8648682, 33.6969227),
+          LatLng(35.3814697, 32.0546447),
+        ],
+      ),
+    );
+    controller.addFill(
+      FillOptions(
+        draggable: false,
+        fillColor: "#008888",
+        fillOpacity: 0.3,
+        geometry: [
+          [
+            LatLng(35.3649902, 32.0593003),
+            LatLng(34.9475098, 31.1187944),
+            LatLng(36.7108154, 30.7040582),
+            LatLng(37.6995850, 33.6512083),
+            LatLng(35.8648682, 33.6969227),
+            LatLng(35.3814697, 32.0546447),
+          ]
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/annotation_order_maps.dart
+++ b/example/lib/annotation_order_maps.dart
@@ -56,7 +56,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                         AnnotationType.line,
                         AnnotationType.symbol,
                         AnnotationType.circle,
-                        AnnotationType.polygone,
+                        AnnotationType.fill,
                       ],
                     ),
                   ),
@@ -88,7 +88,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                         zoom: 5.0,
                       ),
                       annotationOrder: const [
-                        AnnotationType.polygone,
+                        AnnotationType.fill,
                         AnnotationType.line,
                         AnnotationType.symbol,
                         AnnotationType.circle,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:mapbox_gl_example/full_map.dart';
 import 'package:mapbox_gl_example/offline_regions.dart';
 
 import 'animate_camera.dart';
+import 'annotation_order_maps.dart';
 import 'full_map.dart';
 import 'line.dart';
 import 'map_ui.dart';
@@ -32,6 +33,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   PlaceFillPage(),
   ScrollingMapPage(),
   OfflineRegionsPage(),
+  AnnotationOrderPage(),
 ];
 
 class MapsDemo extends StatelessWidget {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -672,7 +672,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
 
         for annotationType in annotationOrder {
             switch annotationType {
-            case "AnnotationType.polygone":
+            case "AnnotationType.fill":
                 fillAnnotationController = MGLPolygonAnnotationController(mapView: self.mapView)
                 fillAnnotationController!.annotationsInteractionEnabled = true
                 fillAnnotationController?.delegate = self
@@ -689,7 +689,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 symbolAnnotationController!.annotationsInteractionEnabled = true
                 symbolAnnotationController?.delegate = self
             default:
-                print("Error with symbol name or unexpected symbol name: \(annotationType)")  
+                print("Unknown annotation type: \(annotationType), must be either 'fill', 'line', 'circle' or 'symbol'")  
             }
         }
 

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -22,6 +22,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     private var lineAnnotationController: MGLLineAnnotationController?
     private var fillAnnotationController: MGLPolygonAnnotationController?
 
+    private var annotationOrder = [String]()
+
     func view() -> UIView {
         return mapView
     }
@@ -62,6 +64,9 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 let zoom = initialCameraPosition["zoom"] as? Double {
                 mapView.setCenter(camera.centerCoordinate, zoomLevel: zoom, direction: camera.heading, animated: false)
                 initialTilt = camera.pitch
+            }
+            if let annotationOrderArg = args["annotationOrder"] as? [String] {
+                annotationOrder = annotationOrderArg
             }
         }
     }
@@ -665,22 +670,29 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             mapView.setCamera(camera, animated: false)
         }
 
-        lineAnnotationController = MGLLineAnnotationController(mapView: self.mapView)
-        lineAnnotationController!.annotationsInteractionEnabled = true
-        lineAnnotationController?.delegate = self
+        for annotationType in annotationOrder {
+            switch annotationType {
+            case "AnnotationType.polygone":
+                fillAnnotationController = MGLPolygonAnnotationController(mapView: self.mapView)
+                fillAnnotationController!.annotationsInteractionEnabled = true
+                fillAnnotationController?.delegate = self
+            case "AnnotationType.line":
+                lineAnnotationController = MGLLineAnnotationController(mapView: self.mapView)
+                lineAnnotationController!.annotationsInteractionEnabled = true
+                lineAnnotationController?.delegate = self
+            case "AnnotationType.circle":
+                circleAnnotationController = MGLCircleAnnotationController(mapView: self.mapView)
+                circleAnnotationController!.annotationsInteractionEnabled = true
+                circleAnnotationController?.delegate = self
+            case "AnnotationType.symbol":
+                symbolAnnotationController = MGLSymbolAnnotationController(mapView: self.mapView)
+                symbolAnnotationController!.annotationsInteractionEnabled = true
+                symbolAnnotationController?.delegate = self
+            default:
+                print("Error with symbol name or unexpected symbol name: \(annotationType)")  
+            }
+        }
 
-        symbolAnnotationController = MGLSymbolAnnotationController(mapView: self.mapView)
-        symbolAnnotationController!.annotationsInteractionEnabled = true
-        symbolAnnotationController?.delegate = self
-        
-        circleAnnotationController = MGLCircleAnnotationController(mapView: self.mapView)
-        circleAnnotationController!.annotationsInteractionEnabled = true
-        circleAnnotationController?.delegate = self
-
-        fillAnnotationController = MGLPolygonAnnotationController(mapView: self.mapView)
-        fillAnnotationController!.annotationsInteractionEnabled = true
-        fillAnnotationController?.delegate = self
-        
         mapReadyResult?(nil)
         if let channel = channel {
             channel.invokeMethod("map#onStyleLoaded", arguments: nil)

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -4,7 +4,7 @@
 
 part of mapbox_gl;
 
-enum AnnotationType { polygone, line, circle, symbol }
+enum AnnotationType { fill, line, circle, symbol }
 
 typedef void MapCreatedCallback(MapboxMapController controller);
 
@@ -43,7 +43,7 @@ class MapboxMap extends StatefulWidget {
       AnnotationType.line,
       AnnotationType.symbol,
       AnnotationType.circle,
-      AnnotationType.polygone,
+      AnnotationType.fill,
     ],
   })  : assert(initialCameraPosition != null),
         assert(annotationOrder != null),

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -4,6 +4,8 @@
 
 part of mapbox_gl;
 
+enum AnnotationType { polygone, line, circle, symbol }
+
 typedef void MapCreatedCallback(MapboxMapController controller);
 
 class MapboxMap extends StatefulWidget {
@@ -37,8 +39,19 @@ class MapboxMap extends StatefulWidget {
     this.onCameraTrackingChanged,
     this.onCameraIdle,
     this.onMapIdle,
+    this.annotationOrder = const [
+      AnnotationType.line,
+      AnnotationType.symbol,
+      AnnotationType.circle,
+      AnnotationType.polygone,
+    ],
   })  : assert(initialCameraPosition != null),
+        assert(annotationOrder.length == 4),
         super(key: key);
+
+  /// Defined the layer order of annotations displayed on map
+  /// (must contain all annotation types, 4 items)
+  final List<AnnotationType> annotationOrder;
 
   /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
   /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
@@ -183,10 +196,13 @@ class _MapboxMapState extends State<MapboxMap> {
 
   @override
   Widget build(BuildContext context) {
+    final List<String> annotationOrder = widget.annotationOrder.map((e) => e.toString()).toList();
+
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition?.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
       'accessToken': widget.accessToken,
+      'annotationOrder': annotationOrder,
     };
     return _mapboxGlPlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);
@@ -225,9 +241,9 @@ class _MapboxMapState extends State<MapboxMap> {
         if (_controller.isCompleted) {
           widget.onStyleLoadedCallback();
         } else {
-          _controller.future.then((_) => widget.onStyleLoadedCallback());
-        }
-      },
+        _controller.future.then((_) => widget.onStyleLoadedCallback());
+      }
+    },
         onMapClick: widget.onMapClick,
         onUserLocationUpdated: widget.onUserLocationUpdated,
         onMapLongClick: widget.onMapLongClick,

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -46,6 +46,7 @@ class MapboxMap extends StatefulWidget {
       AnnotationType.polygone,
     ],
   })  : assert(initialCameraPosition != null),
+        assert(annotationOrder != null),
         assert(annotationOrder.length == 4),
         super(key: key);
 


### PR DESCRIPTION
Hello @tobrun 

Here is a merge request regarding an existing issue marked as enhancement: 
[Circle always on top of Symbols #483](https://github.com/tobrun/flutter-mapbox-gl/issues/483)

Added an optional list of "AnnotationType" to define the order in which the layers should be added on map.
Whenever the list is not passed in the mapbox widget, the default behavior (already in the current master branch) is applied,
which means the old users of the package can update their project without any action to have their apps running as usual.

Also added an AnnotationOrder example page in the example project of the repo so you can easily test and see the changes.

