### PR TITLE
[Offline][iOS][Android] Add option to set maximum offline tile count

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -69,6 +69,10 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
                 OfflineManagerUtils.mergeRegions(result, context, methodCall.argument("path"));
                 break;
 
+            case "setOfflineTileCountLimit":
+                OfflineManagerUtils.setOfflineTileCountLimit(result, context, methodCall.argument("count"));
+                break;
+
             case "downloadOfflineRegion":
                 // Get download region arguments from caller
                 OfflineRegionData regionData = new Gson().fromJson(methodCall.argument("region").toString(), OfflineRegionData.class);

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -70,7 +70,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
                 break;
 
             case "setOfflineTileCountLimit":
-                OfflineManagerUtils.setOfflineTileCountLimit(result, context, methodCall.argument("count"));
+                OfflineManagerUtils.setOfflineTileCountLimit(result, context, methodCall.<Number>argument("limit").longValue());
                 break;
 
             case "downloadOfflineRegion":

--- a/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
@@ -61,11 +61,7 @@ abstract class OfflineManagerUtils {
         //Tracker of result
         AtomicBoolean isComplete = new AtomicBoolean(false);
         //Download region
-        OfflineManager manager = OfflineManager.getInstance(context);
-
-        manager.setOfflineMapboxTileCountLimit(60000);
-
-        manager.createOfflineRegion(definition, metadata, new OfflineManager.CreateOfflineRegionCallback() {
+        OfflineManager.getInstance(context).createOfflineRegion(definition, metadata, new OfflineManager.CreateOfflineRegionCallback() {
             private OfflineRegion _offlineRegion;
 
             @Override

--- a/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
@@ -42,6 +42,11 @@ abstract class OfflineManagerUtils {
         });
     }
 
+    static void setOfflineTileCountLimit(MethodChannel.Result result, Context context, long limit){
+        OfflineManager.getInstance(context).setOfflineMapboxTileCountLimit(limit);
+        result.success(null);
+    }
+
     static void downloadRegion(
         MethodChannel.Result result,
         Context context,
@@ -56,7 +61,11 @@ abstract class OfflineManagerUtils {
         //Tracker of result
         AtomicBoolean isComplete = new AtomicBoolean(false);
         //Download region
-        OfflineManager.getInstance(context).createOfflineRegion(definition, metadata, new OfflineManager.CreateOfflineRegionCallback() {
+        OfflineManager manager = OfflineManager.getInstance(context);
+
+        manager.setOfflineMapboxTileCountLimit(60000);
+
+        manager.createOfflineRegion(definition, metadata, new OfflineManager.CreateOfflineRegionCallback() {
             private OfflineRegion _offlineRegion;
 
             @Override

--- a/ios/Classes/OfflineManagerUtils.swift
+++ b/ios/Classes/OfflineManagerUtils.swift
@@ -65,10 +65,11 @@ class OfflineManagerUtils {
         }
         result(regionsArgsJsonString)
     }
+
     static func setOfflineTileCountLimit(result: @escaping FlutterResult, maximumCount: UInt64) {
         let offlineStorage = MGLOfflineStorage.shared
         offlineStorage.setMaximumAllowedMapboxTiles(maximumCount)
-        result()
+        result(nil)
     }
 
     static func deleteRegion(result: @escaping FlutterResult, id: Int) {

--- a/ios/Classes/OfflineManagerUtils.swift
+++ b/ios/Classes/OfflineManagerUtils.swift
@@ -65,7 +65,12 @@ class OfflineManagerUtils {
         }
         result(regionsArgsJsonString)
     }
-    
+    static func setOfflineTileCountLimit(result: @escaping FlutterResult, maximumCount: UInt64) {
+        let offlineStorage = MGLOfflineStorage.shared
+        offlineStorage.setMaximumAllowedMapboxTiles(maximumCount)
+        result(nil)
+    }
+
     static func deleteRegion(result: @escaping FlutterResult, id: Int) {
         let offlineStorage = MGLOfflineStorage.shared
         guard let pacs = offlineStorage.packs else { return }

--- a/ios/Classes/OfflineManagerUtils.swift
+++ b/ios/Classes/OfflineManagerUtils.swift
@@ -68,7 +68,7 @@ class OfflineManagerUtils {
     static func setOfflineTileCountLimit(result: @escaping FlutterResult, maximumCount: UInt64) {
         let offlineStorage = MGLOfflineStorage.shared
         offlineStorage.setMaximumAllowedMapboxTiles(maximumCount)
-        result(nil)
+        result()
     }
 
     static func deleteRegion(result: @escaping FlutterResult, id: Int) {

--- a/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
+++ b/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
@@ -30,9 +30,16 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                     registrar: registrar
                 )
             case "setOfflineTileCountLimit":
-                guard let arguments = methodCall.arguments as? [String: Int] else { return }
-
-                OfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: arguments["limit"])
+                guard let arguments = methodCall.arguments as? [String: Any],
+                    let limit = arguments["limit"] as? Int else {
+                        result(FlutterError(
+                            code: "SetOfflineTileCountLimitError",
+                            message: "could not decode arguments",
+                            details: nil
+                        ))
+                        return
+                }
+                OfOfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: limit)
 
             case "getListOfRegions":
                 // Note: this does not download anything from internet, it only fetches data drom database

--- a/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
+++ b/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
@@ -1,6 +1,5 @@
 import Flutter
 import UIKit
-import os
 
 public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -41,7 +40,6 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                         return
                 }
                 OfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: limit)
-
             case "getListOfRegions":
                 // Note: this does not download anything from internet, it only fetches data drom database
                 OfflineManagerUtils.regionsList(result: result)

--- a/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
+++ b/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
@@ -29,6 +29,11 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                     result: result,
                     registrar: registrar
                 )
+            case "setOfflineTileCountLimit":
+                guard let arguments = methodCall.arguments as? [String: Int] else { return }
+
+                OfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: arguments["limit"])
+
             case "getListOfRegions":
                 // Note: this does not download anything from internet, it only fetches data drom database
                 OfflineManagerUtils.regionsList(result: result)

--- a/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
+++ b/ios/Classes/SwiftMapboxGlFlutterPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import os
 
 public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -31,7 +32,7 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                 )
             case "setOfflineTileCountLimit":
                 guard let arguments = methodCall.arguments as? [String: Any],
-                    let limit = arguments["limit"] as? Int else {
+                    let limit = arguments["limit"] as? UInt64 else {
                         result(FlutterError(
                             code: "SetOfflineTileCountLimitError",
                             message: "could not decode arguments",
@@ -39,7 +40,7 @@ public class SwiftMapboxGlFlutterPlugin: NSObject, FlutterPlugin {
                         ))
                         return
                 }
-                OfOfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: limit)
+                OfflineManagerUtils.setOfflineTileCountLimit(result: result, maximumCount: limit)
 
             case "getListOfRegions":
                 // Note: this does not download anything from internet, it only fetches data drom database

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -59,6 +59,14 @@ Future<OfflineRegion> updateOfflineRegionMetadata(
   return OfflineRegion.fromJson(json.decode(regionJson));
 }
 
+Future<dynamic> setOfflineTileCountLimit(int limit) =>
+    _globalChannel.invokeMethod(
+      'setOfflineTileCountLimit',
+      <String, dynamic>{
+        'limt': limit,
+      },
+    );
+
 Future<dynamic> deleteOfflineRegion(int id, {String accessToken}) =>
     _globalChannel.invokeMethod(
       'deleteOfflineRegion',

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -59,11 +59,12 @@ Future<OfflineRegion> updateOfflineRegionMetadata(
   return OfflineRegion.fromJson(json.decode(regionJson));
 }
 
-Future<dynamic> setOfflineTileCountLimit(int limit) =>
+Future<dynamic> setOfflineTileCountLimit(int limit, {String accessToken}) =>
     _globalChannel.invokeMethod(
       'setOfflineTileCountLimit',
       <String, dynamic>{
-        'limt': limit,
+        'limit': limit,
+        'accessToken': accessToken,
       },
     );
 


### PR DESCRIPTION
Currently there is no option to change the max offline tile count, which defaults to 6000. I added the support to set this value for iOS and android. Tested for Android and iOS, but iOS offline tiles are still defunct - https://github.com/tobrun/flutter-mapbox-gl/pull/545

Would be nice if one of @n8han  or @shroff could take on the review.