### PR TITLE
[iOS] Add support for colors with alpha

### DIFF
--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -114,7 +114,7 @@ extension UIColor {
                 if scanner.scanHexInt64(&hexNumber) {
                     r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
                     g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
-                    b = CGFloat(hexNumber & 0x0000ff00 >> 8) / 255
+                    b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
                     a = CGFloat(hexNumber & 0x000000ff) / 255
                     
                     self.init(red: r, green: g, blue: b, alpha: a)

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -96,15 +96,26 @@ extension UIColor {
             let start = hexString.index(hexString.startIndex, offsetBy: 1)
             let hexColor = hexString[start...]
             
+            let scanner = Scanner(string: String(hexColor))
+            var hexNumber: UInt64 = 0
+            
             if hexColor.count == 6 {
-                let scanner = Scanner(string: String(hexColor))
-                var hexNumber: UInt64 = 0
-                
                 if scanner.scanHexInt64(&hexNumber) {
                     r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
                     g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
                     b = CGFloat(hexNumber & 0x0000ff) / 255
                     a = 255
+                    
+                    self.init(red: r, green: g, blue: b, alpha: a)
+                    return
+                }
+            } 
+            else if hexColor.count == 8 {
+                if scanner.scanHexInt64(&hexNumber) {
+                    r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                    g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                    b = CGFloat(hexNumber & 0x0000ff00 >> 8) / 255
+                    a = CGFloat(hexNumber & 0x000000ff) / 255
                     
                     self.init(red: r, green: g, blue: b, alpha: a)
                     return

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -112,10 +112,10 @@ extension UIColor {
             } 
             else if hexColor.count == 8 {
                 if scanner.scanHexInt64(&hexNumber) {
-                    r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
-                    g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
-                    b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
-                    a = CGFloat(hexNumber & 0x000000ff) / 255
+                    a = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                    r = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                    g = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+                    b = CGFloat(hexNumber & 0x000000ff) / 255
                     
                     self.init(red: r, green: g, blue: b, alpha: a)
                     return


### PR DESCRIPTION
Currently the iOS version only supports RGB colors such as `#ffee00`. Android also supports colors with alphas such as `#99ffee00` (where `99` would be the alpha value)
The Purpose of this pull request is to add the support to iOS as well. 

The Syntax of the color string for iOS can either follow the old format of #rrggbb or the new format #aarrggbb. Thus this change is downwards compatible and should not break any existing code.
 #aarrggbb is consistent with the android implementation.


