### PR TITLE
Define which annotations consume tap events (Multiple annotations on click area management)

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -72,7 +72,7 @@ class Convert {
     return annotations;
   }
 
-  static List<String> toAnnotationClickOrder(Object o) {
+  static List<String> toAnnotationConsumeTapEvents(Object o) {
     return toAnnotationOrder(o);
   }
 

--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -72,6 +72,10 @@ class Convert {
     return annotations;
   }
 
+  static List<String> toAnnotationClickOrder(Object o) {
+    return toAnnotationOrder(o);
+  }
+
   static boolean isScrollByCameraUpdate(Object o) {
     return toString(toList(o).get(0)).equals("scrollBy");
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -32,11 +32,13 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private int myLocationRenderMode = 0;
   private String styleString = Style.MAPBOX_STREETS;
   private List<String> annotationOrder = new ArrayList();
+  private List<String> annotationClickOrder = new ArrayList();
+
 
   MapboxMapController build(
     int id, Context context, BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider, String accessToken) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString, annotationOrder);
+      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString, annotationOrder, annotationClickOrder);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);
@@ -178,4 +180,9 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   public void setAnnotationOrder(List<String> annotations) {
     this.annotationOrder = annotations;
   }
+
+  public void setAnnotationClickOrder(List<String> annotations) {
+    this.annotationClickOrder = annotations;
+  }
+
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -32,13 +32,13 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   private int myLocationRenderMode = 0;
   private String styleString = Style.MAPBOX_STREETS;
   private List<String> annotationOrder = new ArrayList();
-  private List<String> annotationClickOrder = new ArrayList();
+  private List<String> annotationConsumeTapEvents = new ArrayList();
 
 
   MapboxMapController build(
     int id, Context context, BinaryMessenger messenger, MapboxMapsPlugin.LifecycleProvider lifecycleProvider, String accessToken) {
     final MapboxMapController controller =
-      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString, annotationOrder, annotationClickOrder);
+      new MapboxMapController(id, context,  messenger, lifecycleProvider, options, accessToken, styleString, annotationOrder, annotationConsumeTapEvents);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationTrackingMode(myLocationTrackingMode);
@@ -181,8 +181,8 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
     this.annotationOrder = annotations;
   }
 
-  public void setAnnotationClickOrder(List<String> annotations) {
-    this.annotationClickOrder = annotations;
+  public void setAnnotationConsumeTapEvents(List<String> annotations) {
+    this.annotationConsumeTapEvents = annotations;
   }
 
 }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -39,9 +39,9 @@ public class MapboxMapFactory extends PlatformViewFactory {
       List<String> annotations = Convert.toAnnotationOrder(params.get("annotationOrder"));
       builder.setAnnotationOrder(annotations);
     }
-    if (params.containsKey("annotationClickOrder")) {
-      List<String> annotations = Convert.toAnnotationClickOrder(params.get("annotationClickOrder"));
-      builder.setAnnotationClickOrder(annotations);
+    if (params.containsKey("annotationConsumeTapEvents")) {
+      List<String> annotations = Convert.toAnnotationConsumeTapEvents(params.get("annotationConsumeTapEvents"));
+      builder.setAnnotationConsumeTapEvents(annotations);
     }
     return builder.build(id, context, messenger, lifecycleProvider, (String) params.get("accessToken"));
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -39,6 +39,10 @@ public class MapboxMapFactory extends PlatformViewFactory {
       List<String> annotations = Convert.toAnnotationOrder(params.get("annotationOrder"));
       builder.setAnnotationOrder(annotations);
     }
+    if (params.containsKey("annotationClickOrder")) {
+      List<String> annotations = Convert.toAnnotationClickOrder(params.get("annotationClickOrder"));
+      builder.setAnnotationClickOrder(annotations);
+    }
     return builder.build(id, context, messenger, lifecycleProvider, (String) params.get("accessToken"));
   }
 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -23,6 +23,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     private var fillAnnotationController: MGLPolygonAnnotationController?
 
     private var annotationOrder = [String]()
+    private var annotationClickOrder = [String]()
 
     func view() -> UIView {
         return mapView
@@ -67,6 +68,9 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             }
             if let annotationOrderArg = args["annotationOrder"] as? [String] {
                 annotationOrder = annotationOrderArg
+            }
+            if let annotationClickOrderArg = args["annotationClickOrder"] as? [String] {
+                annotationClickOrder = annotationClickOrderArg
             }
         }
     }
@@ -680,24 +684,39 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             switch annotationType {
             case "AnnotationType.fill":
                 fillAnnotationController = MGLPolygonAnnotationController(mapView: self.mapView)
-                fillAnnotationController!.annotationsInteractionEnabled = true
+                fillAnnotationController!.annotationsInteractionEnabled = false
                 fillAnnotationController?.delegate = self
             case "AnnotationType.line":
                 lineAnnotationController = MGLLineAnnotationController(mapView: self.mapView)
-                lineAnnotationController!.annotationsInteractionEnabled = true
+                lineAnnotationController!.annotationsInteractionEnabled = false
                 lineAnnotationController?.delegate = self
             case "AnnotationType.circle":
                 circleAnnotationController = MGLCircleAnnotationController(mapView: self.mapView)
-                circleAnnotationController!.annotationsInteractionEnabled = true
+                circleAnnotationController!.annotationsInteractionEnabled = false
                 circleAnnotationController?.delegate = self
             case "AnnotationType.symbol":
                 symbolAnnotationController = MGLSymbolAnnotationController(mapView: self.mapView)
-                symbolAnnotationController!.annotationsInteractionEnabled = true
+                symbolAnnotationController!.annotationsInteractionEnabled = false
                 symbolAnnotationController?.delegate = self
             default:
                 print("Unknown annotation type: \(annotationType), must be either 'fill', 'line', 'circle' or 'symbol'")  
             }
         }
+
+        for annotationType in annotationClickOrder {
+                    switch annotationType {
+                    case "AnnotationType.fill":
+                        fillAnnotationController!.annotationsInteractionEnabled = true
+                    case "AnnotationType.line":
+                        lineAnnotationController!.annotationsInteractionEnabled = true
+                    case "AnnotationType.circle":
+                        circleAnnotationController!.annotationsInteractionEnabled = true
+                    case "AnnotationType.symbol":
+                        symbolAnnotationController!.annotationsInteractionEnabled = true
+                    default:
+                        print("Unknown annotation type: \(annotationType), must be either 'fill', 'line', 'circle' or 'symbol'")
+                    }
+                }
 
         mapReadyResult?(nil)
         if let channel = channel {

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -45,7 +45,7 @@ class MapboxMap extends StatefulWidget {
       AnnotationType.circle,
       AnnotationType.fill,
     ],
-    this.annotationClickOrder = const [
+    this.annotationConsumeTapEvents = const [
       AnnotationType.symbol,
       AnnotationType.fill,
       AnnotationType.line,
@@ -54,8 +54,8 @@ class MapboxMap extends StatefulWidget {
   })  : assert(initialCameraPosition != null),
         assert(annotationOrder != null),
         assert(annotationOrder.length == 4),
-        assert(annotationClickOrder != null),
-        assert(annotationClickOrder.length > 0),
+        assert(annotationConsumeTapEvents != null),
+        assert(annotationConsumeTapEvents.length > 0),
         super(key: key);
 
   /// Defined the layer order of annotations displayed on map
@@ -64,7 +64,7 @@ class MapboxMap extends StatefulWidget {
 
   /// Defined the layer order of click annotations
   /// (must contain at least 1 annotation type, 4 items max)
-  final List<AnnotationType> annotationClickOrder;
+  final List<AnnotationType> annotationConsumeTapEvents;
 
   /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
   /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
@@ -211,15 +211,15 @@ class _MapboxMapState extends State<MapboxMap> {
   Widget build(BuildContext context) {
     final List<String> annotationOrder =
         widget.annotationOrder.map((e) => e.toString()).toList();
-    final List<String> annotationClickOrder =
-        widget.annotationClickOrder.map((e) => e.toString()).toList();
+    final List<String> annotationConsumeTapEvents =
+        widget.annotationConsumeTapEvents.map((e) => e.toString()).toList();
 
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition?.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
       'accessToken': widget.accessToken,
       'annotationOrder': annotationOrder,
-      'annotationClickOrder': annotationClickOrder,
+      'annotationConsumeTapEvents': annotationConsumeTapEvents,
     };
     return _mapboxGlPlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -45,14 +45,26 @@ class MapboxMap extends StatefulWidget {
       AnnotationType.circle,
       AnnotationType.fill,
     ],
+    this.annotationClickOrder = const [
+      AnnotationType.symbol,
+      AnnotationType.fill,
+      AnnotationType.line,
+      AnnotationType.circle,
+    ],
   })  : assert(initialCameraPosition != null),
         assert(annotationOrder != null),
         assert(annotationOrder.length == 4),
+        assert(annotationClickOrder != null),
+        assert(annotationClickOrder.length > 0),
         super(key: key);
 
   /// Defined the layer order of annotations displayed on map
   /// (must contain all annotation types, 4 items)
   final List<AnnotationType> annotationOrder;
+
+  /// Defined the layer order of click annotations
+  /// (must contain at least 1 annotation type, 4 items max)
+  final List<AnnotationType> annotationClickOrder;
 
   /// If you want to use Mapbox hosted styles and map tiles, you need to provide a Mapbox access token.
   /// Obtain a free access token on [your Mapbox account page](https://www.mapbox.com/account/access-tokens/).
@@ -197,13 +209,17 @@ class _MapboxMapState extends State<MapboxMap> {
 
   @override
   Widget build(BuildContext context) {
-    final List<String> annotationOrder = widget.annotationOrder.map((e) => e.toString()).toList();
+    final List<String> annotationOrder =
+        widget.annotationOrder.map((e) => e.toString()).toList();
+    final List<String> annotationClickOrder =
+        widget.annotationClickOrder.map((e) => e.toString()).toList();
 
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition?.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
       'accessToken': widget.accessToken,
       'annotationOrder': annotationOrder,
+      'annotationClickOrder': annotationClickOrder,
     };
     return _mapboxGlPlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);
@@ -236,12 +252,10 @@ class _MapboxMapState extends State<MapboxMap> {
   Future<void> onPlatformViewCreated(int id) async {
     MapboxGlPlatform.addInstance(id, _mapboxGlPlatform);
     final MapboxMapController controller = MapboxMapController.init(
-      id,
-      widget.initialCameraPosition,
-      onStyleLoadedCallback: () {
-        if (_controller.isCompleted) {
-          widget.onStyleLoadedCallback();
-        } else {
+        id, widget.initialCameraPosition, onStyleLoadedCallback: () {
+      if (_controller.isCompleted) {
+        widget.onStyleLoadedCallback();
+      } else {
         _controller.future.then((_) => widget.onStyleLoadedCallback());
       }
     },
@@ -251,8 +265,7 @@ class _MapboxMapState extends State<MapboxMap> {
         onCameraTrackingDismissed: widget.onCameraTrackingDismissed,
         onCameraTrackingChanged: widget.onCameraTrackingChanged,
         onCameraIdle: widget.onCameraIdle,
-        onMapIdle: widget.onMapIdle
-    );
+        onMapIdle: widget.onMapIdle);
     await MapboxMapController.initPlatform(id);
     _controller.complete(controller);
     if (widget.onMapCreated != null) {


### PR DESCRIPTION
Hello @tobrun

Here is a merge request regarding an existing issue mentioned here: https://github.com/tobrun/flutter-mapbox-gl/issues/563

Added an optional list of "AnnotationType" to define which annotation(s) have to consume tap events.

If FALSE, there is both AnnotationClick + MapClick launched
If TRUE, there is only AnnotationClick.

It's very useful to have FALSE in case of multiple Annotations at the click.

Whenever the list is not passed in the MapBox widget, the default behavior (already in the current master branch) is applied (consumeTapEvents = true to all annotations), which means the old users of the package can update their project without any action to have their apps running as usual.