### PR TITLE
[iOS][Android] Batch creation/removal for circles, fills and lines

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/CircleBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/CircleBuilder.java
@@ -21,6 +21,10 @@ class CircleBuilder implements CircleOptionsSink {
     this.circleOptions = new CircleOptions();
   }
 
+  public CircleOptions getCircleOptions(){
+    return this.circleOptions;
+  }
+
   Circle build() {
     return circleManager.create(circleOptions);
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/CircleController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/CircleController.java
@@ -24,6 +24,10 @@ class CircleController implements CircleOptionsSink {
     this.onTappedListener = onTappedListener;
   }
 
+  public Circle getCircle(){
+    return this.circle;
+  }
+
   boolean onTap() {
     if (onTappedListener != null) {
       onTappedListener.onCircleTapped(circle);

--- a/android/src/main/java/com/mapbox/mapboxgl/FillBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/FillBuilder.java
@@ -22,6 +22,10 @@ class FillBuilder implements FillOptionsSink {
     this.fillOptions = new FillOptions();
   }
 
+  public FillOptions getFillOptions(){
+    return this.fillOptions;
+  }
+
   Fill build() {
     return fillManager.create(fillOptions);
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/FillController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/FillController.java
@@ -27,6 +27,10 @@ class FillController implements FillOptionsSink {
     this.onTappedListener = onTappedListener;
   }
 
+  public Fill getFill(){
+    return this.fill;
+  }
+
   boolean onTap() {
     if (onTappedListener != null) {
       onTappedListener.onFillTapped(fill);

--- a/android/src/main/java/com/mapbox/mapboxgl/LineBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineBuilder.java
@@ -22,6 +22,10 @@ class LineBuilder implements LineOptionsSink {
     this.lineOptions = new LineOptions();
   }
 
+  public LineOptions getLineOptions(){
+    return this.lineOptions;
+  }
+
   Line build() {
     return lineManager.create(lineOptions);
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/LineController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/LineController.java
@@ -32,6 +32,10 @@ class LineController implements LineOptionsSink {
     this.onTappedListener = onTappedListener;
   }
 
+  public Line getLine(){
+    return this.line;
+  }
+
   boolean onTap() {
     if (onTappedListener != null) {
       onTappedListener.onLineTapped(line);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -55,10 +55,13 @@ import com.mapbox.mapboxsdk.offline.OfflineManager;
 import com.mapbox.mapboxsdk.plugins.annotation.Annotation;
 import com.mapbox.mapboxsdk.plugins.annotation.Circle;
 import com.mapbox.mapboxsdk.plugins.annotation.CircleManager;
+import com.mapbox.mapboxsdk.plugins.annotation.CircleOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.Fill;
 import com.mapbox.mapboxsdk.plugins.annotation.FillManager;
+import com.mapbox.mapboxsdk.plugins.annotation.FillOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.Line;
 import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
+import com.mapbox.mapboxsdk.plugins.annotation.LineOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.OnAnnotationClickListener;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
@@ -627,7 +630,7 @@ final class MapboxMapController
         break;
       }
       case "symbols#removeAll": {
-        final ArrayList<String> symbolIds = call.argument("symbols");
+        final ArrayList<String> symbolIds = call.argument("ids");
         SymbolController symbolController;
 
         List<Symbol> symbolList = new ArrayList<Symbol>();
@@ -699,6 +702,47 @@ final class MapboxMapController
         result.success(null);
         break;
       }
+      case "line#addAll": { 
+        List<String> newIds = new ArrayList<String>();
+        final List<Object> options = call.argument("options");
+        List<LineOptions> optionList = new ArrayList<LineOptions>();
+        if (options != null) {
+          LineBuilder builder;
+          for (Object o : options) {
+            builder = newLineBuilder();
+            Convert.interpretLineOptions(o, builder);
+            optionList.add(builder.getLineOptions());
+          }
+          if (!optionList.isEmpty()) {
+            List<Line> newLines = lineManager.create(optionList);
+            String id;
+            for (Line line : newLines) {
+              id = String.valueOf(line.getId());
+              newIds.add(id);
+              lines.put(id, new LineController(line, true, this));
+            }
+          }
+        }
+        result.success(newIds);
+        break;
+      }
+      case "line#removeAll": {
+        final ArrayList<String> ids = call.argument("ids");
+        LineController lineController;
+
+        List<Line> toBeRemoved = new ArrayList<Line>();
+        for(String id : ids){
+            lineController = lines.remove(id);
+            if (lineController != null) {
+              toBeRemoved.add(lineController.getLine());
+            }
+        }
+        if(!toBeRemoved.isEmpty()) {
+          lineManager.delete(toBeRemoved);
+        }
+        result.success(null);
+        break;
+      }
       case "line#update": {
         final String lineId = call.argument("line");
         final LineController line = line(lineId);
@@ -728,6 +772,47 @@ final class MapboxMapController
         final String circleId = String.valueOf(circle.getId());
         circles.put(circleId, new CircleController(circle,  annotationConsumeTapEvents.contains("AnnotationType.circle"), this));
         result.success(circleId);
+        break;
+      }
+      case "circle#addAll": { 
+        List<String> newIds = new ArrayList<String>();
+        final List<Object> options = call.argument("options");
+        List<CircleOptions> optionList = new ArrayList<CircleOptions>();
+        if (options != null) {
+          CircleBuilder builder;
+          for (Object o : options) {
+            builder = newCircleBuilder();
+            Convert.interpretCircleOptions(o, builder);
+            optionList.add(builder.getCircleOptions());
+          }
+          if (!optionList.isEmpty()) {
+            List<Circle> newCircles = circleManager.create(optionList);
+            String id;
+            for (Circle circle : newCircles) {
+              id = String.valueOf(circle.getId());
+              newIds.add(id);
+              circles.put(id, new CircleController(circle, true, this));
+            }
+          }
+        }
+        result.success(newIds);
+        break;
+      }
+      case "circle#removeAll": {
+        final ArrayList<String> ids = call.argument("ids");
+        CircleController circleController;
+
+        List<Circle> toBeRemoved = new ArrayList<Circle>();
+        for(String id : ids){
+            circleController = circles.remove(id);
+            if (circleController != null) {
+              toBeRemoved.add(circleController.getCircle());
+            }
+        }
+        if(!toBeRemoved.isEmpty()) {
+          circleManager.delete(toBeRemoved);
+        }
+        result.success(null);
         break;
       }
       case "circle#remove": {
@@ -762,6 +847,48 @@ final class MapboxMapController
         final String fillId = String.valueOf(fill.getId());
         fills.put(fillId, new FillController(fill,  annotationConsumeTapEvents.contains("AnnotationType.fill"), this));
         result.success(fillId);
+        break;
+      }
+
+      case "fill#addAll": { 
+        List<String> newIds = new ArrayList<String>();
+        final List<Object> options = call.argument("options");
+        List<FillOptions> optionList = new ArrayList<FillOptions>();
+        if (options != null) {
+          FillBuilder builder;
+          for (Object o : options) {
+            builder = newFillBuilder();
+            Convert.interpretFillOptions(o, builder);
+            optionList.add(builder.getFillOptions());
+          }
+          if (!optionList.isEmpty()) {
+            List<Fill> newFills = fillManager.create(optionList);
+            String id;
+            for (Fill fill : newFills) {
+              id = String.valueOf(fill.getId());
+              newIds.add(id);
+              fills.put(id, new FillController(fill, true, this));
+            }
+          }
+        }
+        result.success(newIds);
+        break;
+      }
+      case "fill#removeAll": {
+        final ArrayList<String> ids = call.argument("ids");
+        FillController fillController;
+
+        List<Fill> toBeRemoved = new ArrayList<Fill>();
+        for(String id : ids){
+            fillController = fills.remove(id);
+            if (fillController != null) {
+              toBeRemoved.add(fillController.getFill());
+            }
+        }
+        if(!toBeRemoved.isEmpty()) {
+          fillManager.delete(toBeRemoved);
+        }
+        result.success(null);
         break;
       }
       case "fill#remove": {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:location/location.dart';
 import 'package:mapbox_gl_example/custom_marker.dart';
 import 'package:mapbox_gl_example/full_map.dart';
 import 'package:mapbox_gl_example/offline_regions.dart';
+import 'package:mapbox_gl_example/place_batch.dart';
 
 import 'animate_camera.dart';
 import 'annotation_order_maps.dart';
@@ -38,6 +39,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   OfflineRegionsPage(),
   AnnotationOrderPage(),
   CustomMarkerPage(),
+  BatchAddPage(),
 ];
 
 class MapsDemo extends StatelessWidget {

--- a/example/lib/place_batch.dart
+++ b/example/lib/place_batch.dart
@@ -1,0 +1,189 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:mapbox_gl_example/main.dart';
+
+import 'page.dart';
+
+const fillOptions = [
+  FillOptions(
+    geometry: [
+      [
+        LatLng(-33.719, 151.150),
+        LatLng(-33.858, 151.150),
+        LatLng(-33.866, 151.401),
+        LatLng(-33.747, 151.328),
+        LatLng(-33.719, 151.150),
+      ],
+      [
+        LatLng(-33.762, 151.250),
+        LatLng(-33.827, 151.250),
+        LatLng(-33.833, 151.347),
+        LatLng(-33.762, 151.250),
+      ]
+    ],
+    fillColor: "#FF0000",
+  ),
+  FillOptions(geometry: [
+    [
+      LatLng(-33.719, 151.550),
+      LatLng(-33.858, 151.550),
+      LatLng(-33.866, 151.801),
+      LatLng(-33.747, 151.728),
+      LatLng(-33.719, 151.550),
+    ],
+    [
+      LatLng(-33.762, 151.650),
+      LatLng(-33.827, 151.650),
+      LatLng(-33.833, 151.747),
+      LatLng(-33.762, 151.650),
+    ]
+  ], fillColor: "#FF0000"),
+];
+
+class BatchAddPage extends ExamplePage {
+  BatchAddPage() : super(const Icon(Icons.check_circle), 'Batch add/remove');
+
+  @override
+  Widget build(BuildContext context) {
+    return const BatchAddBody();
+  }
+}
+
+class BatchAddBody extends StatefulWidget {
+  const BatchAddBody();
+
+  @override
+  State<StatefulWidget> createState() => BatchAddBodyState();
+}
+
+class BatchAddBodyState extends State<BatchAddBody> {
+  BatchAddBodyState();
+  List<Fill> _fills = [];
+  List<Circle> _circles = [];
+  List<Line> _lines = [];
+  List<Symbol> _symbols = [];
+
+  static final LatLng center = const LatLng(-33.86711, 151.1947171);
+
+  MapboxMapController controller;
+
+  void _onMapCreated(MapboxMapController controller) {
+    this.controller = controller;
+  }
+
+  List<LineOptions> makeLinesOptionsForFillOptions(
+      Iterable<FillOptions> options) {
+    final listOptions = <LineOptions>[];
+    for (final option in options) {
+      for (final geom in option.geometry) {
+        listOptions.add(LineOptions(geometry: geom, lineColor: "#00FF00"));
+      }
+    }
+    return listOptions;
+  }
+
+  List<CircleOptions> makeCircleOptionsForFillOptions(
+      Iterable<FillOptions> options) {
+    final circleOptions = <CircleOptions>[];
+    for (final option in options) {
+      // put circles only on the outside
+      for (final latLng in option.geometry.first) {
+        circleOptions
+            .add(CircleOptions(geometry: latLng, circleColor: "#00FF00"));
+      }
+    }
+    return circleOptions;
+  }
+
+  List<SymbolOptions> makeSymbolOptionsForFillOptions(
+      Iterable<FillOptions> options) {
+    final symbolOptions = <SymbolOptions>[];
+    for (final option in options) {
+      // put symbols only on the inner most ring if it exists
+      if (option.geometry.length > 1)
+        for (final latLng in option.geometry.last) {
+          symbolOptions
+              .add(SymbolOptions(iconImage: 'hospital-11', geometry: latLng));
+        }
+    }
+    return symbolOptions;
+  }
+
+  void _add() async {
+    if (_fills.isEmpty) {
+      _fills = await controller.addFills(fillOptions);
+      _lines = await controller
+          .addLines(makeLinesOptionsForFillOptions(fillOptions));
+      _circles = await controller
+          .addCircles(makeCircleOptionsForFillOptions(fillOptions));
+      _symbols = await controller
+          .addSymbols(makeSymbolOptionsForFillOptions(fillOptions));
+    }
+  }
+
+  void _remove() {
+    controller.removeFills(_fills);
+    controller.removeLines(_lines);
+    controller.removeCircles(_circles);
+    controller.removeSymbols(_symbols);
+    _fills.clear();
+    _lines.clear();
+    _circles.clear();
+    _symbols.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Center(
+          child: SizedBox(
+            height: 200.0,
+            child: MapboxMap(
+              accessToken: MapsDemo.ACCESS_TOKEN,
+              onMapCreated: _onMapCreated,
+              initialCameraPosition: const CameraPosition(
+                target: LatLng(-33.8, 151.511),
+                zoom: 8.2,
+              ),
+              annotationOrder: const [
+                AnnotationType.fill,
+                AnnotationType.line,
+                AnnotationType.circle,
+                AnnotationType.symbol,
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Column(
+                      children: <Widget>[
+                        TextButton(
+                            child: const Text('batch add'), onPressed: _add),
+                        TextButton(
+                            child: const Text('batch remove'),
+                            onPressed: _remove),
+                      ],
+                    ),
+                  ],
+                )
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -698,7 +698,6 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         default:
             result(FlutterMethodNotImplemented)
         }
-        NSLog("methodCall.method")
     }
     
     private func getSymbolForOptions(options: [String: Any]) -> MGLSymbolStyleAnnotation? {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -74,6 +74,11 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             }
         }
     }
+    func removeAllForController(controller: MGLAnnotationController, ids: [String]){
+        let idSet = Set(ids)
+        let annotations = controller.styleAnnotations()
+        controller.removeStyleAnnotations(annotations.filter { idSet.contains($0.identifier) })
+    }
     
     func onMethodCall(methodCall: FlutterMethodCall, result: @escaping FlutterResult) {
         switch(methodCall.method) {
@@ -281,16 +286,11 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         case "symbols#removeAll":
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let symbolIds = arguments["symbols"] as? [String] else { return }
-            var symbols: [MGLSymbolStyleAnnotation] = [];
+            guard let symbolIds = arguments["ids"] as? [String] else { return }
 
-            for symbol in symbolAnnotationController.styleAnnotations(){
-                if symbolIds.contains(symbol.identifier) {
-                    symbols.append(symbol as! MGLSymbolStyleAnnotation)
-                }
-            }
-            symbolAnnotationController.removeStyleAnnotations(symbols)
+            removeAllForController(controller:symbolAnnotationController, ids:symbolIds)
             result(nil)
+
         case "symbol#getGeometry":
             guard let symbolAnnotationController = symbolAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -346,6 +346,34 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             } else {
                 result(nil)
             }
+
+        case "circle#addAll":
+            guard let circleAnnotationController = circleAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            // Parse geometry
+            var identifier: String? = nil
+            if let allOptions = arguments["options"] as? [[String: Any]]{
+                var circles: [MGLCircleStyleAnnotation] = [];
+
+                for options in allOptions {
+                    if let geometry = options["geometry"] as? [Double] {
+                        guard geometry.count > 0 else { break }
+
+                        let coordinate = CLLocationCoordinate2DMake(geometry[0], geometry[1])
+                        let circle = MGLCircleStyleAnnotation(center: coordinate)
+                        Convert.interpretCircleOptions(options: options, delegate: circle)
+                        circles.append(circle)
+                    }
+                }
+                if !circles.isEmpty {
+                    circleAnnotationController.addStyleAnnotations(circles)
+                }
+                result(circles.map { $0.identifier })
+            }
+            else {
+                result(nil)
+            }
+  
         case "circle#update":
             guard let circleAnnotationController = circleAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -371,6 +399,16 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+
+        case "circle#removeAll":
+            guard let circleAnnotationController = circleAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let ids = arguments["ids"] as? [String] else { return }
+
+            removeAllForController(controller:circleAnnotationController, ids:ids)
+            result(nil)
+
+        
         case "line#add":
             guard let lineAnnotationController = lineAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -390,6 +428,38 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             } else {
                 result(nil)
             }
+        
+        case "line#addAll":
+            guard let lineAnnotationController = lineAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            // Parse geometry
+            var identifier: String? = nil
+            if let allOptions = arguments["options"] as? [[String: Any]]{
+                var lines: [MGLLineStyleAnnotation] = [];
+
+                for options in allOptions {
+                    if let geometry = options["geometry"] as? [[Double]] {
+                        guard geometry.count > 0 else { break }
+                        // Convert geometry to coordinate and create a line.
+                        var lineCoordinates: [CLLocationCoordinate2D] = []
+                        for coordinate in geometry {
+                            lineCoordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
+                        }
+                        let line = MGLLineStyleAnnotation(coordinates: lineCoordinates, count: UInt(lineCoordinates.count))
+                        Convert.interpretLineOptions(options: options, delegate: line)
+                        lines.append(line)
+                    }
+                }
+                if !lines.isEmpty {
+                    lineAnnotationController.addStyleAnnotations(lines)
+                }
+                result(lines.map { $0.identifier })
+            }
+            else {
+                result(nil)
+            }
+  
+
         case "line#update":
             guard let lineAnnotationController = lineAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -415,6 +485,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+
+        case "line#removeAll":
+            guard let lineAnnotationController = lineAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let ids = arguments["ids"] as? [String] else { return }
+
+            removeAllForController(controller:lineAnnotationController, ids:ids)
+            result(nil)
+
         case "line#getGeometry":
             guard let lineAnnotationController = lineAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -451,7 +530,40 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 fillAnnotationController.annotationsInteractionEnabled = annotationConsumeTapEvents.contains("AnnotationType.fill")
                 identifier = fill.identifier
             }
+
             result(identifier)
+
+        case "fill#addAll":
+            guard let fillAnnotationController = fillAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            // Parse geometry
+            var identifier: String? = nil
+            if let allOptions = arguments["options"] as? [[String: Any]]{
+                var fills: [MGLPolygonStyleAnnotation] = [];
+
+                for options in allOptions{
+                    if let geometry = options["geometry"] as? [[[Double]]] {
+                        guard geometry.count > 0 else { break }
+                        // Convert geometry to coordinate and interior polygonc.
+                        var fillCoordinates: [CLLocationCoordinate2D] = []
+                        for coordinate in geometry[0] {
+                            fillCoordinates.append(CLLocationCoordinate2DMake(coordinate[0], coordinate[1]))
+                        }
+                        let polygons = Convert.toPolygons(geometry: geometry.tail)
+                        let fill = MGLPolygonStyleAnnotation(coordinates: fillCoordinates, count: UInt(fillCoordinates.count), interiorPolygons: polygons)
+                        Convert.interpretFillOptions(options: options, delegate: fill)
+                        fills.append(fill)
+                    }
+                }
+                if !fills.isEmpty {
+                    fillAnnotationController.addStyleAnnotations(fills)
+                }
+                result(fills.map { $0.identifier })
+            }
+            else {
+                result(nil)
+            }
+
         case "fill#update":
             guard let fillAnnotationController = fillAnnotationController else { return }
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -464,6 +576,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                     break;
                 }
             }
+            
             result(nil)
         case "fill#remove":
             guard let fillAnnotationController = fillAnnotationController else { return }
@@ -477,6 +590,15 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 }
             }
             result(nil)
+
+        case "fill#removeAll":
+            guard let fillAnnotationController = fillAnnotationController else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let ids = arguments["ids"] as? [String] else { return }
+
+            removeAllForController(controller:fillAnnotationController, ids:ids)
+            result(nil)
+
         case "style#addImage":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let name = arguments["name"] as? String else { return }
@@ -491,6 +613,8 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 self.mapView.style?.setImage(image, forName: name)
             }
             result(nil)
+
+            
         case "style#addImageSource":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             guard let imageSourceId = arguments["imageSourceId"] as? String else { return }
@@ -574,6 +698,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         default:
             result(FlutterMethodNotImplemented)
         }
+        NSLog("methodCall.method")
     }
     
     private func getSymbolForOptions(options: [String: Any]) -> MGLSymbolStyleAnnotation? {

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -100,7 +100,7 @@ class MapboxMapController extends ChangeNotifier {
         .add((cameraPosition) {
       _isCameraMoving = false;
       if (cameraPosition != null) {
-        _cameraPosition = cameraPosition;        
+        _cameraPosition = cameraPosition;
       }
       if (onCameraIdle != null) {
         onCameraIdle();
@@ -222,17 +222,27 @@ class MapboxMapController extends ChangeNotifier {
   Set<Line> get lines => Set<Line>.from(_lines.values);
   final Map<String, Line> _lines = <String, Line>{};
 
+  final _lineToDeleteIds = <String>[];
+  final _lineToAddOptions = <CircleOptions>[];
+
   /// The current set of circles on this map.
   ///
   /// The returned set will be a detached snapshot of the circles collection.
   Set<Circle> get circles => Set<Circle>.from(_circles.values);
   final Map<String, Circle> _circles = <String, Circle>{};
 
+  final _circleToDeleteIds = <String>[];
+  final _circleToAddOptions = <CircleOptions>[];
+
   /// The current set of fills on this map.
   ///
   /// The returned set will be a detached snapshot of the fills collection.
   Set<Fill> get fills => Set<Fill>.from(_fills.values);
   final Map<String, Fill> _fills = <String, Fill>{};
+
+  final _fillToDeleteIds = <String>[];
+  final _fillToAddOptions = <CircleOptions>[];
+  final _resultingIdStreams = <Stream<String>>[];
 
   /// True if the map camera is currently moving.
   bool get isCameraMoving => _isCameraMoving;
@@ -533,6 +543,17 @@ class MapboxMapController extends ChangeNotifier {
     _lines.remove(id);
   }
 
+  void removeLineLazy(Line line) {
+    assert(line != null);
+    assert(_lines[line.id] == line);
+    _lineToDeleteIds.add(line.id);
+  }
+
+  void removeLazyLines() async {
+    await MapboxGlPlatform.getInstance(_id).removeCircles(_lineToDeleteIds);
+    _lineToDeleteIds.forEach((id) => _lines.remove(id))
+  }
+
   /// Adds a circle to the map, configured using the specified custom [options].
   ///
   /// Change listeners are notified once the circle has been added on the
@@ -590,6 +611,17 @@ class MapboxMapController extends ChangeNotifier {
     assert(_circles[circle.id] == circle);
     await _removeCircle(circle.id);
     notifyListeners();
+  }
+
+  void removeCircleLazy(Circle circle) {
+    assert(circle != null);
+    assert(_circles[circle.id] == circle);
+    _circleToDeleteIds.add(circle.id);
+  }
+
+  void removeLazyCircles() async {
+    await MapboxGlPlatform.getInstance(_id).removeCircles(_circleToDeleteIds);
+    _circleToDeleteIds.forEach((id) => _circles.remove(id));
   }
 
   /// Removes all [circles] from the map.
@@ -678,6 +710,17 @@ class MapboxMapController extends ChangeNotifier {
     assert(_fills[fill.id] == fill);
     await _removeFill(fill.id);
     notifyListeners();
+  }
+
+  void removeFillLazy(Fill fill) {
+    assert(fill != null);
+    assert(_fills[fill.id] == fill);
+    _fillToDeleteIds.add(fill.id);
+  }
+
+  void removeLazyFills() async {
+    await MapboxGlPlatform.getInstance(_id).removeFills(_fillToDeleteIds);
+    _fillToDeleteIds.forEach((id) => _fills.remove(id));
   }
 
   /// Helper method to remove a single fill from the map. Consumed by

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -222,27 +222,17 @@ class MapboxMapController extends ChangeNotifier {
   Set<Line> get lines => Set<Line>.from(_lines.values);
   final Map<String, Line> _lines = <String, Line>{};
 
-  final _lineToDeleteIds = <String>[];
-  final _lineToAddOptions = <CircleOptions>[];
-
   /// The current set of circles on this map.
   ///
   /// The returned set will be a detached snapshot of the circles collection.
   Set<Circle> get circles => Set<Circle>.from(_circles.values);
   final Map<String, Circle> _circles = <String, Circle>{};
 
-  final _circleToDeleteIds = <String>[];
-  final _circleToAddOptions = <CircleOptions>[];
-
   /// The current set of fills on this map.
   ///
   /// The returned set will be a detached snapshot of the fills collection.
   Set<Fill> get fills => Set<Fill>.from(_fills.values);
   final Map<String, Fill> _fills = <String, Fill>{};
-
-  final _fillToDeleteIds = <String>[];
-  final _fillToAddOptions = <CircleOptions>[];
-  final _resultingIdStreams = <Stream<String>>[];
 
   /// True if the map camera is currently moving.
   bool get isCameraMoving => _isCameraMoving;

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -476,8 +476,17 @@ class MapboxMapController extends ChangeNotifier {
     return line;
   }
 
+  Future<List<Line>> addLines(List<LineOptions> options,
+      [List<Map> data]) async {
+    final lines =
+        await MapboxGlPlatform.getInstance(_id).addLines(options, data);
+    lines.forEach((l) => _lines[l.id] = l);
+    notifyListeners();
+    return lines;
+  }
+
   /// Updates the specified [line] with the given [changes]. The line must
-  /// be a current member of the [lines] set.
+  /// be a current member of the [lines] set.‚
   ///
   /// Change listeners are notified once the line has been updated on the
   /// platform side.
@@ -518,6 +527,14 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> removeLines(List<Line> lines) async {
+    final checkedLines = lines.where((l) => _lines[l.id] == l).map((l) => l.id);
+    assert(checkedLines.length == lines.length);
+    await MapboxGlPlatform.getInstance(_id).removeLines(checkedLines);
+    checkedLines.forEach((id) => _lines.remove(id));
+    notifyListeners();
+  }
+
   /// Removes all [lines] from the map.
   ///
   /// Change listeners are notified once all lines have been removed on the
@@ -527,9 +544,8 @@ class MapboxMapController extends ChangeNotifier {
   Future<void> clearLines() async {
     assert(_lines != null);
     final List<String> lineIds = List<String>.from(_lines.keys);
-    for (String id in lineIds) {
-      await _removeLine(id);
-    }
+    await MapboxGlPlatform.getInstance(_id).removeLines(lineIds);
+    _lines.clear();
     notifyListeners();
   }
 
@@ -550,8 +566,8 @@ class MapboxMapController extends ChangeNotifier {
   }
 
   void removeLazyLines() async {
-    await MapboxGlPlatform.getInstance(_id).removeCircles(_lineToDeleteIds);
-    _lineToDeleteIds.forEach((id) => _lines.remove(id))
+    await MapboxGlPlatform.getInstance(_id).removeLines(_lineToDeleteIds);
+    _lineToDeleteIds.forEach((id) => _lines.remove(id));
   }
 
   /// Adds a circle to the map, configured using the specified custom [options].
@@ -569,6 +585,15 @@ class MapboxMapController extends ChangeNotifier {
     _circles[circle.id] = circle;
     notifyListeners();
     return circle;
+  }
+
+  Future<List<Circle>> addCircles(List<CircleOptions> options,
+      [List<Map> data]) async {
+    final circles =
+        await MapboxGlPlatform.getInstance(_id).addCircles(options, data);
+    circles.forEach((c) => _circles[c.id] = c);
+    notifyListeners();
+    return circles;
   }
 
   /// Updates the specified [circle] with the given [changes]. The circle must
@@ -632,10 +657,9 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes once listeners have been notified.
   Future<void> clearCircles() async {
     assert(_circles != null);
-    final List<String> circleIds = List<String>.from(_circles.keys);
-    for (String id in circleIds) {
-      await _removeCircle(id);
-    }
+    await MapboxGlPlatform.getInstance(_id).removeCircles(_circles.keys);
+    _circles.clear();
+
     notifyListeners();
   }
 
@@ -658,6 +682,25 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes with the added fill once listeners have
   /// been notified.
   Future<Fill> addFill(FillOptions options, [Map data]) async {
+    final FillOptions effectiveOptions =
+        FillOptions.defaultOptions.copyWith(options);
+    final fill =
+        await MapboxGlPlatform.getInstance(_id).addFill(effectiveOptions, data);
+    _fills[fill.id] = fill;
+    notifyListeners();
+    return fill;
+  }
+
+  Future<List<Fill>> addFills(List<FillOptions> options,
+      [List<Map> data]) async {
+    final circles =
+        await MapboxGlPlatform.getInstance(_id).addFills(options, data);
+    circles.forEach((f) => _fills[f.id] = f);
+    notifyListeners();
+    return circles;
+  }
+
+  Future<Fill> addFillLazy(FillOptions options, [Map data]) async {
     final FillOptions effectiveOptions =
         FillOptions.defaultOptions.copyWith(options);
     final fill =
@@ -691,10 +734,9 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes once listeners have been notified.
   Future<void> clearFills() async {
     assert(_fills != null);
-    final List<String> fillIds = List<String>.from(_fills.keys);
-    for (String id in fillIds) {
-      await _removeFill(id);
-    }
+    await MapboxGlPlatform.getInstance(_id).removeFills(_fills.keys);
+    _fills.clear();
+
     notifyListeners();
   }
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -372,6 +372,14 @@ class MapboxMapController extends ChangeNotifier {
     return result.first;
   }
 
+  /// Adds multiple symbols to the map, configured using the specified custom
+  /// [options].
+  ///
+  /// Change listeners are notified once the symbol has been added on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes with the added symbol once listeners have
+  /// been notified.
   Future<List<Symbol>> addSymbols(List<SymbolOptions> options,
       [List<Map> data]) async {
     final List<SymbolOptions> effectiveOptions =
@@ -426,6 +434,13 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Removes the specified [symbols] from the map. The symbols must be current
+  /// members of the [symbols] set.
+  ///
+  /// Change listeners are notified once the symbol has been removed on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
   Future<void> removeSymbols(Iterable<Symbol> symbols) async {
     final ids = symbols.where((s) => _symbols[s.id] == s).map((s) => s.id);
     assert(symbols.length == ids.length);
@@ -474,6 +489,13 @@ class MapboxMapController extends ChangeNotifier {
     return line;
   }
 
+  /// Adds multiple lines to the map, configured using the specified custom [options].
+  ///
+  /// Change listeners are notified once the lines have been added on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes with the added line once listeners have
+  /// been notified.
   Future<List<Line>> addLines(List<LineOptions> options,
       [List<Map> data]) async {
     final lines =
@@ -527,6 +549,13 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Removes the specified [lines] from the map. The lines must be current
+  /// members of the [lines] set.
+  ///
+  /// Change listeners are notified once the lines have been removed on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
   Future<void> removeLines(Iterable<Line> lines) async {
     final ids = lines.where((l) => _lines[l.id] == l).map((l) => l.id);
     assert(lines.length == ids.length);
@@ -567,6 +596,14 @@ class MapboxMapController extends ChangeNotifier {
     return circle;
   }
 
+  /// Adds multiple circles to the map, configured using the specified custom
+  /// [options].
+  ///
+  /// Change listeners are notified once the circles have been added on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes with the added circle once listeners have
+  /// been notified.
   Future<List<Circle>> addCircles(List<CircleOptions> options,
       [List<Map> data]) async {
     final circles =
@@ -621,6 +658,13 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Removes the specified [circles] from the map. The circles must be current
+  /// members of the [circles] set.
+  ///
+  /// Change listeners are notified once the circles have been removed on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
   Future<void> removeCircles(Iterable<Circle> circles) async {
     assert(circles != null);
     final ids = circles.where((c) => _circles[c.id] == c).map((c) => c.id);
@@ -662,6 +706,14 @@ class MapboxMapController extends ChangeNotifier {
     return fill;
   }
 
+  /// Adds multiple fills to the map, configured using the specified custom
+  /// [options].
+  ///
+  /// Change listeners are notified once the fills has been added on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes with the added fills once listeners have
+  /// been notified.
   Future<List<Fill>> addFills(List<FillOptions> options,
       [List<Map> data]) async {
     final circles =
@@ -717,6 +769,13 @@ class MapboxMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Removes the specified [fills] from the map. The fills must be current
+  /// members of the [fills] set.
+  ///
+  /// Change listeners are notified once the fills have been removed on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
   Future<void> removeFills(Iterable<Fill> fills) async {
     final ids = fills.where((f) => _fills[f.id] == f).map((f) => f.id);
     assert(fills.length == ids.length);

--- a/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/mapbox_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -63,8 +63,9 @@ abstract class MapboxGlPlatform {
       ArgumentCallbacks<void>();
 
   final ArgumentCallbacks<void> onMapIdlePlatform = ArgumentCallbacks<void>();
-  
-  final ArgumentCallbacks<UserLocation> onUserLocationUpdatedPlatform = ArgumentCallbacks<UserLocation>();
+
+  final ArgumentCallbacks<UserLocation> onUserLocationUpdatedPlatform =
+      ArgumentCallbacks<UserLocation>();
 
   Future<void> initPlatform(int id) async {
     throw UnimplementedError('initPlatform() has not been implemented.');
@@ -116,8 +117,9 @@ abstract class MapboxGlPlatform {
   Future<bool> getTelemetryEnabled() async {
     throw UnimplementedError('getTelemetryEnabled() has not been implemented.');
   }
-  
-  Future<List<Symbol>> addSymbols(List<SymbolOptions> options, [List<Map> data]) async {
+
+  Future<List<Symbol>> addSymbols(List<SymbolOptions> options,
+      [List<Map> data]) async {
     throw UnimplementedError('addSymbols() has not been implemented.');
   }
 
@@ -133,6 +135,11 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('addLine() has not been implemented.');
   }
 
+  Future<List<Line>> addLines(List<LineOptions> options,
+      [List<Map> data]) async {
+    throw UnimplementedError('addLines() has not been implemented.');
+  }
+
   Future<void> updateLine(Line line, LineOptions changes) async {
     throw UnimplementedError('updateLine() has not been implemented.');
   }
@@ -141,8 +148,17 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('removeLine() has not been implemented.');
   }
 
+  Future<void> removeLines(Iterable<String> ids) async {
+    throw UnimplementedError('removeLines() has not been implemented.');
+  }
+
   Future<Circle> addCircle(CircleOptions options, [Map data]) async {
     throw UnimplementedError('addCircle() has not been implemented.');
+  }
+
+  Future<List<Circle>> addCircles(List<CircleOptions> options,
+      [List<Map> data]) async {
+    throw UnimplementedError('addCircles() has not been implemented.');
   }
 
   Future<void> updateCircle(Circle circle, CircleOptions changes) async {
@@ -165,16 +181,29 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('removeCircle() has not been implemented.');
   }
 
+  Future<void> removeCircles(Iterable<String> ids) async {
+    throw UnimplementedError('removeCircles() has not been implemented.');
+  }
+
   Future<Fill> addFill(FillOptions options, [Map data]) async {
     throw UnimplementedError('addFill() has not been implemented.');
   }
 
-  Future<void>updateFill(Fill fill, FillOptions changes) async {
+  Future<List<Fill>> addFills(List<FillOptions> options,
+      [List<Map> data]) async {
+    throw UnimplementedError('addFills() has not been implemented.');
+  }
+
+  Future<void> updateFill(Fill fill, FillOptions changes) async {
     throw UnimplementedError('updateFill() has not been implemented.');
   }
 
   Future<void> removeFill(String fillId) async {
     throw UnimplementedError('removeFill() has not been implemented.');
+  }
+
+  Future<void> removeFills(Iterable<String> fillIds) async {
+    throw UnimplementedError('removeFills() has not been implemented.');
   }
 
   Future<List> queryRenderedFeatures(
@@ -228,8 +257,8 @@ abstract class MapboxGlPlatform {
         'setSymbolTextIgnorePlacement() has not been implemented.');
   }
 
-  Future<void> addImageSource(String imageSourceId, Uint8List bytes,
-      LatLngQuad coordinates) async {
+  Future<void> addImageSource(
+      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) async {
     throw UnimplementedError('addImageSource() has not been implemented.');
   }
 
@@ -241,7 +270,8 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('addLayer() has not been implemented.');
   }
 
-  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) async {
+  Future<void> addLayerBelow(
+      String imageLayerId, String imageSourceId, String belowLayerId) async {
     throw UnimplementedError('addLayerBelow() has not been implemented.');
   }
 
@@ -249,9 +279,8 @@ abstract class MapboxGlPlatform {
     throw UnimplementedError('removeLayer() has not been implemented.');
   }
 
-  Future<Point> toScreenLocation(LatLng latLng) async{
-    throw UnimplementedError(
-        'toScreenLocation() has not been implemented.');
+  Future<Point> toScreenLocation(LatLng latLng) async {
+    throw UnimplementedError('toScreenLocation() has not been implemented.');
   }
 
   Future<List<Point>> toScreenLocationBatch(Iterable<LatLng> latLngs) async{
@@ -264,7 +293,7 @@ abstract class MapboxGlPlatform {
         'toLatLng() has not been implemented.');
   }
 
-  Future<double> getMetersPerPixelAtLatitude(double latitude) async{
+  Future<double> getMetersPerPixelAtLatitude(double latitude) async {
     throw UnimplementedError(
         'getMetersPerPixelAtLatitude() has not been implemented.');
   }

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -260,7 +260,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   @override
   Future<void> removeSymbols(Iterable<String> ids) async {
     await _channel.invokeMethod('symbols#removeAll', <String, dynamic>{
-      'ids': ids.toList(), //todo
+      'ids': ids.toList(),
     });
   }
 

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -279,7 +279,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   Future<List<Line>> addLines(List<LineOptions> options,
       [List<Map> data]) async {
     final List<dynamic> ids = await _channel.invokeMethod(
-      'fills#addAll',
+      'line#addAll',
       <String, dynamic>{
         'options': options.map((o) => o.toJson()).toList(),
       },
@@ -343,6 +343,25 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
+  Future<List<Circle>> addCircles(List<CircleOptions> options,
+      [List<Map> data]) async {
+    final List<dynamic> ids = await _channel.invokeMethod(
+      'circle#addAll',
+      <String, dynamic>{
+        'options': options.map((o) => o.toJson()).toList(),
+      },
+    );
+    return ids
+        .asMap()
+        .map((i, id) => MapEntry(
+            i,
+            Circle(id, options.elementAt(i),
+                data != null && data.length > i ? data.elementAt(i) : null)))
+        .values
+        .toList();
+  }
+
+  @override
   Future<void> updateCircle(Circle circle, CircleOptions changes) async {
     await _channel.invokeMethod('circle#update', <String, dynamic>{
       'circle': circle.id,
@@ -367,6 +386,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
+  Future<void> removeCircles(Iterable<String> ids) async {
+    await _channel.invokeMethod('circle#removeAll', <String, dynamic>{
+      'ids': ids.toList(),
+    });
+  }
+
+  @override
   Future<Fill> addFill(FillOptions options, [Map data]) async {
     final String fillId = await _channel.invokeMethod(
       'fill#add',
@@ -381,7 +407,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   Future<List<Fill>> addFills(List<FillOptions> options,
       [List<Map> data]) async {
     final List<dynamic> ids = await _channel.invokeMethod(
-      'fills#addAll',
+      'fill#addAll',
       <String, dynamic>{
         'options': options.map((o) => o.toJson()).toList(),
       },
@@ -415,7 +441,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
 
   @override
   Future<void> removeFills(Iterable<String> ids) async {
-    await _channel.invokeMethod('fills#removeAll', <String, dynamic>{
+    await _channel.invokeMethod('fill#removeAll', <String, dynamic>{
       'ids': ids.toList(),
     });
   }

--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -83,7 +83,8 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
         final dynamic heading = call.arguments['heading'];
         if (onUserLocationUpdatedPlatform != null) {
           onUserLocationUpdatedPlatform(UserLocation(
-              position: LatLng(userLocation['position'][0], userLocation['position'][1]),
+              position: LatLng(
+                  userLocation['position'][0], userLocation['position'][1]),
               altitude: userLocation['altitude'],
               bearing: userLocation['bearing'],
               speed: userLocation['speed'],
@@ -259,7 +260,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   @override
   Future<void> removeSymbols(Iterable<String> ids) async {
     await _channel.invokeMethod('symbols#removeAll', <String, dynamic>{
-      'symbols': ids.toList(),
+      'ids': ids.toList(), //todo
     });
   }
 
@@ -272,6 +273,27 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       },
     );
     return Line(lineId, options, data);
+  }
+
+  @override
+  Future<List<Line>> addLines(List<LineOptions> options,
+      [List<Map> data]) async {
+    final List<dynamic> ids = await _channel.invokeMethod(
+      'fills#addAll',
+      <String, dynamic>{
+        'options': options.map((o) => o.toJson()).toList(),
+      },
+    );
+    final List<Line> lines = ids
+        .asMap()
+        .map((i, id) => MapEntry(
+            i,
+            Line(id, options.elementAt(i),
+                data != null && data.length > i ? data.elementAt(i) : null)))
+        .values
+        .toList();
+
+    return lines;
   }
 
   @override
@@ -299,6 +321,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   Future<void> removeLine(String lineId) async {
     await _channel.invokeMethod('line#remove', <String, dynamic>{
       'line': lineId,
+    });
+  }
+
+  @override
+  Future<void> removeLines(Iterable<String> ids) async {
+    await _channel.invokeMethod('line#removeAll', <String, dynamic>{
+      'ids': ids.toList(),
     });
   }
 
@@ -349,6 +378,27 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
+  Future<List<Fill>> addFills(List<FillOptions> options,
+      [List<Map> data]) async {
+    final List<dynamic> ids = await _channel.invokeMethod(
+      'fills#addAll',
+      <String, dynamic>{
+        'options': options.map((o) => o.toJson()).toList(),
+      },
+    );
+    final List<Fill> fills = ids
+        .asMap()
+        .map((i, id) => MapEntry(
+            i,
+            Fill(id, options.elementAt(i),
+                data != null && data.length > i ? data.elementAt(i) : null)))
+        .values
+        .toList();
+
+    return fills;
+  }
+
+  @override
   Future<void> updateFill(Fill fill, FillOptions changes) async {
     await _channel.invokeMethod('fill#update', <String, dynamic>{
       'fill': fill.id,
@@ -360,6 +410,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   Future<void> removeFill(String fillId) async {
     await _channel.invokeMethod('fill#remove', <String, dynamic>{
       'fill': fillId,
+    });
+  }
+
+  @override
+  Future<void> removeFills(Iterable<String> ids) async {
+    await _channel.invokeMethod('fills#removeAll', <String, dynamic>{
+      'ids': ids.toList(),
     });
   }
 
@@ -515,10 +572,11 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
-  Future<void> addImageSource(String imageSourceId, Uint8List bytes,
-      LatLngQuad coordinates) async {
+  Future<void> addImageSource(
+      String imageSourceId, Uint8List bytes, LatLngQuad coordinates) async {
     try {
-      return await _channel.invokeMethod('style#addImageSource', <String, Object>{
+      return await _channel
+          .invokeMethod('style#addImageSource', <String, Object>{
         'imageSourceId': imageSourceId,
         'bytes': bytes,
         'length': bytes.length,
@@ -532,10 +590,10 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   @override
   Future<Point> toScreenLocation(LatLng latLng) async {
     try {
-      var screenPosMap = await _channel
-          .invokeMethod('map#toScreenLocation', <String, dynamic>{
+      var screenPosMap =
+          await _channel.invokeMethod('map#toScreenLocation', <String, dynamic>{
         'latitude': latLng.latitude,
-        'longitude':latLng.longitude,
+        'longitude': latLng.longitude,
       });
       return Point(screenPosMap['x'], screenPosMap['y']);
     } on PlatformException catch (e) {
@@ -565,14 +623,13 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   @override
   Future<void> removeImageSource(String imageSourceId) async {
     try {
-      return await _channel.invokeMethod('style#removeImageSource', <String, Object>{
-        'imageSourceId': imageSourceId
-      });
+      return await _channel.invokeMethod('style#removeImageSource',
+          <String, Object>{'imageSourceId': imageSourceId});
     } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }
-  
+
   @override
   Future<void> addLayer(String imageLayerId, String imageSourceId) async {
     try {
@@ -586,9 +643,11 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
-  Future<void> addLayerBelow(String imageLayerId, String imageSourceId, String belowLayerId) async {
+  Future<void> addLayerBelow(
+      String imageLayerId, String imageSourceId, String belowLayerId) async {
     try {
-      return await _channel.invokeMethod('style#addLayerBelow', <String, Object>{
+      return await _channel
+          .invokeMethod('style#addLayerBelow', <String, Object>{
         'imageLayerId': imageLayerId,
         'imageSourceId': imageSourceId,
         'belowLayerId': belowLayerId
@@ -597,25 +656,24 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       return new Future.error(e);
     }
   }
-  
+
   @override
   Future<void> removeLayer(String imageLayerId) async {
     try {
-      return await _channel.invokeMethod('style#removeLayer', <String, Object>{
-        'imageLayerId': imageLayerId
-      });
+      return await _channel.invokeMethod(
+          'style#removeLayer', <String, Object>{'imageLayerId': imageLayerId});
     } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }
-  
+
   @override
   Future<LatLng> toLatLng(Point screenLocation) async {
     try {
-      var latLngMap = await _channel
-          .invokeMethod('map#toLatLng', <String, dynamic>{
+      var latLngMap =
+          await _channel.invokeMethod('map#toLatLng', <String, dynamic>{
         'x': screenLocation.x,
-        'y':screenLocation.y,
+        'y': screenLocation.y,
       });
       return LatLng(latLngMap['latitude'], latLngMap['longitude']);
     } on PlatformException catch (e) {
@@ -624,7 +682,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   }
 
   @override
-  Future<double> getMetersPerPixelAtLatitude(double latitude) async{
+  Future<double> getMetersPerPixelAtLatitude(double latitude) async {
     try {
       var latLngMap = await _channel
           .invokeMethod('map#getMetersPerPixelAtLatitude', <String, dynamic>{
@@ -635,5 +693,4 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
       return new Future.error(e);
     }
   }
-
 }


### PR DESCRIPTION
Currently only Symbols supports batch add and remove. This causes performance issues if any significant number of features have to be added or removed from the map. This merge request addresses these issues. The Performance gains seen by me are in the order of 100x. So now adding thousands of features can be done without a performance hit.

#### Breaking Changes
None. This change is fully downwards compatible and should not affect any existing implementations. 

#### Todo

- [x] Add an example page to the example app

Note: i would add web support for batch update in future pull request