### PR TITLE
Remove failed offline pack downloads

### DIFF
--- a/ios/Classes/OfflinePackDownloadManager.swift
+++ b/ios/Classes/OfflinePackDownloadManager.swift
@@ -119,7 +119,7 @@ class OfflinePackDownloader {
         guard let pack = notification.object as? MGLOfflinePack,
             verifyPack(pack: pack) else { return }
         let error = notification.userInfo?[MGLOfflinePackUserInfoKey.error] as? NSError
-        print("Pack download error: \(error?.localizedDescription)")
+        print("Pack download error: \(String(describing: error?.localizedDescription))")
         // set download state to inactive
         isCompleted = true
         channelHandler.onError(
@@ -133,6 +133,7 @@ class OfflinePackDownloader {
             details: nil
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
+            OfflineManagerUtils.deleteRegion(result: result, id: region.id)
             OfflineManagerUtils.releaseDownloader(id:region.id)
         }
     }


### PR DESCRIPTION
When a download error occurs, the app is informed through the channel so
that it can display an appropriate error. However, on subsequent calls
to list the available downloaded packs it is surprising to see that the
failed region download is present as if it had been downloaded.

There is no way for the app to repair this incomplete pack. Therefore,
it seems much better to clean up the failed download as soon as it's
detected. If any tiles were downloaded they will be at least temporarily
in the cache and available to a future re-download attempt. This follows
the same logic as failures caused by hitting the tile limit.