### PR TITLE
Readme web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ Mapbox [recommends](https://docs.mapbox.com/help/tutorials/first-steps-ios-sdk/#
 ## Web Support
 Add the following lines to your web/index.html file:
 
-<script src='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js'></script>
-<link href='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css' rel='stylesheet' />
+```
+   <script src='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js'></script>
+   <link href='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css' rel='stylesheet' />
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ If you access your users' location, you should also add the following key to you
 
 Mapbox [recommends](https://docs.mapbox.com/help/tutorials/first-steps-ios-sdk/#display-the-users-location) the explanation "Shows your location on the map and helps improve the map".
 
+## Web Support
+Add the following lines to your web/index.html file:
+
+<script src='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js'></script>
+<link href='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css' rel='stylesheet' />
+
 ## Documentation
 
 This README file currently houses all of the documentation for this Flutter project. Please visit [mapbox.com/android-docs](https://www.mapbox.com/android-docs/) if you'd like more information about the Mapbox Maps SDK for Android and [mapbox.com/ios-sdk](https://www.mapbox.com/ios-sdk/) for more information about the Mapbox Maps SDK for iOS.


### PR DESCRIPTION
It is not immediately obvious that the JavaScript libraries need to be imported from the Mapbox CDN in order for the plugin to be used with flutter web.  I think it would be useful to include this information in the README file.