### PR TITLE
removeLines changed with removeSymbols

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -447,7 +447,7 @@ class MapboxMapController extends ChangeNotifier {
   /// The returned [Future] completes once listeners have been notified.
   Future<void> clearSymbols() async {
     assert(_symbols != null);
-    await MapboxGlPlatform.getInstance(_id).removeLines(_symbols.keys);
+    await MapboxGlPlatform.getInstance(_id).removeSymbols(_symbols.keys);
     _symbols.clear();
     notifyListeners();
   }


### PR DESCRIPTION
MapBoxController's clearSymbols method was calling removeLines instead of removeSymbols.
Fixed the issue.