### PR TITLE
Update to Mapbox-Android-SDK 9.6.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     dependencies {
-        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.0"
+        implementation "com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.2"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0"
         implementation "com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0"
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-offline-v9:0.7.0'


### PR DESCRIPTION
Current mapbox SDK for android (9.6.0) has an issue with Chinese label in map, upgrading to the latest 9.6.2 solves this issue.

#### SDK 9.6.0
<img src="https://user-images.githubusercontent.com/4735350/127749003-284b6b92-4bff-4bfa-9d6c-7948a9b4f10d.png" width="200">

#### SDK 9.6.2
<img src="https://user-images.githubusercontent.com/4735350/127749020-a880277c-8f32-481b-a4e2-c8ab7ae4c464.png" width="200">
