### PR TITLE
[Change] setAttributionMargin to use left margin

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1323,7 +1323,7 @@ final class MapboxMapController
 
   @Override
   public void setAttributionButtonMargins(int x, int y) {
-    mapboxMap.getUiSettings().setAttributionMargins(0, 0, x, y);
+    mapboxMap.getUiSettings().setAttributionMargins(x, 0, 0, y);
   }
 
   private void updateMyLocationEnabled() {


### PR DESCRIPTION
Attribution margins is inconsistent with how it is initialized and is not working as of this writing.

```java

// In MapboxMapBuilder.java; It is initialized with left and bottom margins.
  @Override
  public void setAttributionButtonMargins(int x, int y) {
    options.attributionMargins(new int[] {
            (int) x, //left
            (int) 0, //top
            (int) 0, //right
            (int) y, //bottom
    });
  }

// In MapboxMapController.java
  @Override
  public void setAttributionButtonMargins(int x, int y) {
    mapboxMap.getUiSettings().setAttributionMargins(0, 0, x, y);
  }
```

Changes:

```java
// In MapboxMapController.java
  @Override
  public void setAttributionButtonMargins(int x, int y) {
    // Use left margins as right margins doesn't work.
    mapboxMap.getUiSettings().setAttributionMargins(x, 0, 0, y); 
  }
```

