### PR TITLE
Fix requestMyLocationLatLng in the platform interface

### DIFF
--- a/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/mapbox_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -498,7 +498,7 @@ class MethodChannelMapboxGl extends MapboxGlPlatform {
   @override
   Future<LatLng> requestMyLocationLatLng() async {
     try {
-      final Map<Object, Object> reply = await _channel.invokeMethod(
+      final Map<dynamic, dynamic> reply = await _channel.invokeMethod(
           'locationComponent#getLastLocation', null);
       double latitude = 0.0, longitude = 0.0;
       if (reply.containsKey('latitude') && reply['latitude'] != null) {


### PR DESCRIPTION
It was crashing for me with the following error:
```
flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: type '_InternalLinkedHashMap<Object?, Object?>' is not a subtype of type 'Map<Object, Object>'
```

No reason to use <Object, Object> types instead of <dynamic, dynamic> as
used everywhere else