### PR TITLE
[android] Make build work with instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,26 @@ An alternative method to provide access tokens that was required until the v0.7 
 
 ### SDK Download token
 
-You must also [configure a secret access token having the Download: read
-scope][https://docs.mapbox.com/ios/maps/guides/install/]. If this configuration
-is not present, an error like the following appears during the iOS build.
+You must also configure a secret access token having the *Download: read* scope for
+(Android)[https://docs.mapbox.com/android/maps/guides/install/] and/or 
+(iOS)[https://docs.mapbox.com/ios/maps/guides/install/].
 
+If this configuration is not present, an error like the following appears during 
+the build process:
+
+#### Android
+```
+* What went wrong:
+A problem occurred evaluating project ':mapbox_gl'.
+> SDK Registry token is null. See README.md for more information.
+```
+
+#### iOS
 ```
 [!] Error installing Mapbox-iOS-SDK
 curl: (22) The requested URL returned error: 401 Unauthorized
 ```
+
 
 ## Avoid Android UnsatisfiedLinkError
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 rootProject.allprojects {
-    def token = System.getenv('SDK_REGISTRY_TOKEN')
+    def token = System.getenv('SDK_REGISTRY_TOKEN') ?: project.properties['MAPBOX_DOWNLOAD_TOKEN']
     if (token == null || token.empty) {
         throw new Exception("SDK Registry token is null. See README.md for more information.")
     }


### PR DESCRIPTION
`build.gradle` currently does not respect the `MAPBOX_DOWNLOADS_TOKEN`
project property as subbested by the official docs for Android at
https://docs.mapbox.com/android/maps/guides/install/.

This approach does not interfere with the `SDK_REGISTRY_TOKEN`
environment variable used for CI, but just uses the official approach as
a fallback.

Also updated docs