### PR TITLE
fixed crashes with ios offline manager

### DIFF
--- a/ios/Classes/OfflineManagerUtils.swift
+++ b/ios/Classes/OfflineManagerUtils.swift
@@ -70,6 +70,7 @@ class OfflineManagerUtils {
             }
         })
         if let packToRemoveUnwrapped = packToRemove {
+            // deletion is only safe if the download is suspended
             packToRemoveUnwrapped.suspend()
             OfflineManagerUtils.releaseDownloader(id: id)
 

--- a/ios/Classes/OfflinePackDownloadManager.swift
+++ b/ios/Classes/OfflinePackDownloadManager.swift
@@ -134,7 +134,6 @@ class OfflinePackDownloader {
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
             OfflineManagerUtils.deleteRegion(result: result, id: region.id)
-            OfflineManagerUtils.releaseDownloader(id:region.id)
         }
     }
     


### PR DESCRIPTION
Canceling a download or a if download that exceeds the max tile count, will cause an exception and kill the whole flutter app. This fixes these issues.