### PR TITLE
Enable `onMapIdle` callback for android

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -94,6 +94,7 @@ final class MapboxMapController
   MapboxMap.OnCameraIdleListener,
   MapboxMap.OnCameraMoveListener,
   MapboxMap.OnCameraMoveStartedListener,
+  MapView.OnDidBecomeIdleListener,
   OnAnnotationClickListener,
   MapboxMap.OnMapClickListener,
   MapboxMap.OnMapLongClickListener,
@@ -269,6 +270,8 @@ final class MapboxMapController
         mapboxMap.getStyle().addImage(id, bitmap);
       }
     });
+
+    mapView.addOnDidBecomeIdleListener(this);
 
     setStyleString(styleStringInitial);
     // updateMyLocationEnabled();
@@ -1025,6 +1028,11 @@ final class MapboxMapController
   public void onCameraTrackingDismissed() {
     this.myLocationTrackingMode = 0;
     methodChannel.invokeMethod("map#onCameraTrackingDismissed", new HashMap<>());
+  }
+
+  @Override
+  public void onDidBecomeIdle() {
+    methodChannel.invokeMethod("map#onIdle", new HashMap<>());
   }
 
   @Override


### PR DESCRIPTION
This is the android piece of PR #214.

The listener `MapView.OnDidBecomeIdleListener` is less well 
documented than its iOS counterpart. We just have this to go on:

> Interface definition for a callback to be invoked when the map has
> entered the idle state.

https://docs.mapbox.com/android/maps/api/9.6.1/com/mapbox/mapboxsdk/maps/MapView.OnDidBecomeIdleListener.html

For the iOS framework method we have more detailed information:

> Tells the delegate that the map view is entering an idle state, and no
> more drawing will be necessary until new data is loaded or there is
> some interaction with the map.
> * No camera transitions are in progress
> * All currently requested tiles have loaded
> * All fade/transition animations have completed

https://docs.mapbox.com/archive/ios/maps/api/5.6.1/Protocols/MGLMapViewDelegate.html#/c:objc(pl)MGLMapViewDelegate(im)mapViewDidBecomeIdle:

After testing with these changes, it does seem to be the case that it is
only invoked after the tiles are loaded. So I think this is the correct
analogue for the iOS listener.