### PR TITLE
 Add attribution button gravity, position normally 

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -4,7 +4,10 @@
 
 package com.mapbox.mapboxgl;
 
+import android.content.Context;
 import android.graphics.Point;
+import android.util.DisplayMetrics;
+
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
@@ -235,7 +238,8 @@ class Convert {
     return (String) o;
   }
 
-  static void interpretMapboxMapOptions(Object o, MapboxMapOptionsSink sink) {
+  static void interpretMapboxMapOptions(Object o, MapboxMapOptionsSink sink, Context context) {
+    final DisplayMetrics metrics = context.getResources().getDisplayMetrics();
     final Map<?, ?> data = toMap(o);
     final Object cameraTargetBounds = data.get("cameraTargetBounds");
     if (cameraTargetBounds != null) {
@@ -292,7 +296,8 @@ class Convert {
     final Object logoViewMargins = data.get("logoViewMargins");
     if(logoViewMargins != null){
       final List logoViewMarginsData = toList(logoViewMargins);
-      sink.setLogoViewMargins(toInt(logoViewMarginsData.get(0)), toInt(logoViewMarginsData.get(1)));
+      final Point point = toPoint(logoViewMarginsData, metrics.density);
+      sink.setLogoViewMargins(point.x, point.y);
     }
     final Object compassGravity = data.get("compassViewPosition");
     if(compassGravity != null){
@@ -301,12 +306,15 @@ class Convert {
     final Object compassViewMargins = data.get("compassViewMargins");
     if(compassViewMargins != null){
       final List compassViewMarginsData = toList(compassViewMargins);
-      sink.setCompassViewMargins(toInt(compassViewMarginsData.get(0)), toInt(compassViewMarginsData.get(1)));
+      final Point point = toPoint(compassViewMarginsData, metrics.density);
+      sink.setCompassViewMargins(point.x, point.y);
     }
     final Object attributionButtonMargins = data.get("attributionButtonMargins");
     if(attributionButtonMargins != null){
       final List attributionButtonMarginsData = toList(attributionButtonMargins);
-      sink.setAttributionButtonMargins(toInt(attributionButtonMarginsData.get(0)), toInt(attributionButtonMarginsData.get(1)));
+      final Point point = toPoint(attributionButtonMarginsData, metrics.density);
+      final int attributionButtonWidth = toPixels(21, metrics.density);
+      sink.setAttributionButtonMargins(metrics.widthPixels - point.x - attributionButtonWidth, point.y);
     }
   }
 

--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -309,12 +309,15 @@ class Convert {
       final Point point = toPoint(compassViewMarginsData, metrics.density);
       sink.setCompassViewMargins(point.x, point.y);
     }
+    final Object attributionButtonGravity = data.get("attributionButtonPosition");
+    if(attributionButtonGravity != null){
+      sink.setAttributionButtonGravity(toInt(attributionButtonGravity));
+    }
     final Object attributionButtonMargins = data.get("attributionButtonMargins");
     if(attributionButtonMargins != null){
       final List attributionButtonMarginsData = toList(attributionButtonMargins);
       final Point point = toPoint(attributionButtonMarginsData, metrics.density);
-      final int attributionButtonWidth = toPixels(21, metrics.density);
-      sink.setAttributionButtonMargins(metrics.widthPixels - point.x - attributionButtonWidth, point.y);
+      sink.setAttributionButtonMargins(point.x, point.y);
     }
   }
 

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -168,13 +168,42 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   }
 
   @Override
+  public void setAttributionButtonGravity(int gravity) {
+    switch(gravity){
+      case 0:
+        options.attributionGravity(Gravity.TOP | Gravity.START);
+        break;
+      default:
+      case 1:
+        options.attributionGravity(Gravity.TOP | Gravity.END);
+        break;
+      case 2:
+        options.attributionGravity(Gravity.BOTTOM | Gravity.START);
+        break;
+      case 3:
+        options.attributionGravity(Gravity.BOTTOM | Gravity.END);
+        break;
+    }
+  }
+
+  @Override
   public void setAttributionButtonMargins(int x, int y) {
-    options.attributionMargins(new int[] {
-            (int) x, //left
-            (int) 0, //top
-            (int) 0, //right
-            (int) y, //bottom
-    });
+    switch(options.getAttributionGravity())
+    {
+      case Gravity.TOP | Gravity.START:
+        options.attributionMargins(new int[] {(int) x, (int) y, 0, 0});
+        break;
+      default:
+      case Gravity.TOP | Gravity.END:
+        options.attributionMargins(new int[] {0, (int) y, (int) x, 0});
+        break;
+      case Gravity.BOTTOM | Gravity.START:
+        options.attributionMargins(new int[] {(int) x, 0, 0, (int) y});
+        break;
+      case Gravity.BOTTOM | Gravity.END:
+        options.attributionMargins(new int[] {0, 0, (int) x, (int) y});
+        break;
+    }
   }
 
   public void setAnnotationOrder(List<String> annotations) {

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -118,7 +118,7 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
   public void setMyLocationRenderMode(int myLocationRenderMode) {
     this.myLocationRenderMode = myLocationRenderMode;
   }
-  
+
   public void setLogoViewMargins(int x, int y) {
         options.logoMargins(new int[] {
             (int) x, //left
@@ -134,7 +134,6 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
       case 0:
         options.compassGravity(Gravity.TOP | Gravity.START);
         break;
-      default:
       case 1:
         options.compassGravity(Gravity.TOP | Gravity.END);
         break;
@@ -154,6 +153,8 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
       case Gravity.TOP | Gravity.START:
         options.compassMargins(new int[] {(int) x, (int) y, 0, 0});
         break;
+      // If the application code has not specified gravity, assume the platform
+      // default for the compass which is top-right
       default:
       case Gravity.TOP | Gravity.END:
         options.compassMargins(new int[] {0, (int) y, (int) x, 0});
@@ -173,7 +174,6 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
       case 0:
         options.attributionGravity(Gravity.TOP | Gravity.START);
         break;
-      default:
       case 1:
         options.attributionGravity(Gravity.TOP | Gravity.END);
         break;
@@ -193,10 +193,12 @@ class MapboxMapBuilder implements MapboxMapOptionsSink {
       case Gravity.TOP | Gravity.START:
         options.attributionMargins(new int[] {(int) x, (int) y, 0, 0});
         break;
-      default:
       case Gravity.TOP | Gravity.END:
         options.attributionMargins(new int[] {0, (int) y, (int) x, 0});
         break;
+      // If the application code has not specified gravity, assume the platform
+      // default for the attribution button which is bottom left
+      default:
       case Gravity.BOTTOM | Gravity.START:
         options.attributionMargins(new int[] {(int) x, 0, 0, (int) y});
         break;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -418,7 +418,7 @@ final class MapboxMapController
         mapReadyResult = result;
         break;
       case "map#update": {
-        Convert.interpretMapboxMapOptions(call.argument("options"), this);
+        Convert.interpretMapboxMapOptions(call.argument("options"), this, context);
         result.success(Convert.toJson(getCameraPosition()));
         break;
       }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -318,7 +318,7 @@ final class MapboxMapController
             throw new IllegalArgumentException("Unknown annotation type: " + annotationType + ", must be either 'fill', 'line', 'circle' or 'symbol'");
         }
       }
-      
+
       if (myLocationEnabled) {
         enableLocationComponent(style);
       }
@@ -703,7 +703,7 @@ final class MapboxMapController
         result.success(null);
         break;
       }
-      case "line#addAll": { 
+      case "line#addAll": {
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<LineOptions> optionList = new ArrayList<LineOptions>();
@@ -775,7 +775,7 @@ final class MapboxMapController
         result.success(circleId);
         break;
       }
-      case "circle#addAll": { 
+      case "circle#addAll": {
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<CircleOptions> optionList = new ArrayList<CircleOptions>();
@@ -851,7 +851,7 @@ final class MapboxMapController
         break;
       }
 
-      case "fill#addAll": { 
+      case "fill#addAll": {
         List<String> newIds = new ArrayList<String>();
         final List<Object> options = call.argument("options");
         List<FillOptions> optionList = new ArrayList<FillOptions>();
@@ -1322,8 +1322,42 @@ final class MapboxMapController
   }
 
   @Override
+  public void setAttributionButtonGravity(int gravity) {
+    switch(gravity) {
+      case 0:
+        mapboxMap.getUiSettings().setAttributionGravity(Gravity.TOP | Gravity.START);
+        break;
+      default:
+      case 1:
+        mapboxMap.getUiSettings().setAttributionGravity(Gravity.TOP | Gravity.END);
+        break;
+      case 2:
+        mapboxMap.getUiSettings().setAttributionGravity(Gravity.BOTTOM | Gravity.START);
+        break;
+      case 3:
+        mapboxMap.getUiSettings().setAttributionGravity(Gravity.BOTTOM | Gravity.END);
+        break;
+    }
+  }
+
+  @Override
   public void setAttributionButtonMargins(int x, int y) {
-    mapboxMap.getUiSettings().setAttributionMargins(x, 0, 0, y);
+    switch(mapboxMap.getUiSettings().getAttributionGravity())
+    {
+      case Gravity.TOP | Gravity.START:
+        mapboxMap.getUiSettings().setAttributionMargins(x, y, 0, 0);
+        break;
+      default:
+      case Gravity.TOP | Gravity.END:
+        mapboxMap.getUiSettings().setAttributionMargins(0, y, x, 0);
+        break;
+      case Gravity.BOTTOM | Gravity.START:
+        mapboxMap.getUiSettings().setAttributionMargins(x, 0, 0, y);
+        break;
+      case Gravity.BOTTOM | Gravity.END:
+        mapboxMap.getUiSettings().setAttributionMargins(0, 0, x, y);
+        break;
+    }
   }
 
   private void updateMyLocationEnabled() {

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapFactory.java
@@ -30,7 +30,7 @@ public class MapboxMapFactory extends PlatformViewFactory {
     Map<String, Object> params = (Map<String, Object>) args;
     final MapboxMapBuilder builder = new MapboxMapBuilder();
 
-    Convert.interpretMapboxMapOptions(params.get("options"), builder);
+    Convert.interpretMapboxMapOptions(params.get("options"), builder, context);
     if (params.containsKey("initialCameraPosition")) {
       CameraPosition position = Convert.toCameraPosition(params.get("initialCameraPosition"));
       builder.setInitialCameraPosition(position);

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapOptionsSink.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapOptionsSink.java
@@ -41,5 +41,7 @@ interface MapboxMapOptionsSink {
 
   void setCompassViewMargins(int x, int y);
 
+  void setAttributionButtonGravity(int gravity);
+
   void setAttributionButtonMargins(int x, int y);
 }

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -52,8 +52,11 @@ class Convert {
         if let attributionButtonMargins = options["attributionButtonMargins"] as? [Double] {
             delegate.setAttributionButtonMargins(x: attributionButtonMargins[0], y: attributionButtonMargins[1])
         }
+        if let attributionButtonPosition = options["attributionButtonPosition"] as? UInt, let position = MGLOrnamentPosition(rawValue: attributionButtonPosition) {
+            delegate.setAttributionButtonPosition(position: position)
+        }
     }
-    
+
     class func parseCameraUpdate(cameraUpdate: [Any], mapView: MGLMapView) -> MGLMapCamera? {
         guard let type = cameraUpdate[0] as? String else { return nil }
         switch (type) {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -1070,4 +1070,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     func setAttributionButtonMargins(x: Double, y: Double) {
         mapView.attributionButtonMargins = CGPoint(x: x, y: y)
     }
+    func setAttributionButtonPosition(position: MGLOrnamentPosition) {
+        mapView.attributionButtonPosition = position
+    }
 }

--- a/ios/Classes/MapboxMapOptionsSink.swift
+++ b/ios/Classes/MapboxMapOptionsSink.swift
@@ -18,4 +18,5 @@ protocol MapboxMapOptionsSink {
     func setCompassViewPosition(position: MGLOrnamentPosition)
     func setCompassViewMargins(x: Double, y: Double)
     func setAttributionButtonMargins(x: Double, y: Double)
+    func setAttributionButtonPosition(position: MGLOrnamentPosition)
 }

--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -33,6 +33,7 @@ export 'package:mapbox_gl_platform_interface/mapbox_gl_platform_interface.dart'
         MyLocationTrackingMode,
         MyLocationRenderMode,
         CompassViewPosition,
+        AttributionButtonPosition,
         Circle,
         CircleOptions,
         Line,

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -31,6 +31,7 @@ class MapboxMap extends StatefulWidget {
     this.logoViewMargins,
     this.compassViewPosition,
     this.compassViewMargins,
+    this.attributionButtonPosition,
     this.attributionButtonMargins,
     this.onMapClick,
     this.onUserLocationUpdated,
@@ -156,7 +157,13 @@ class MapboxMap extends StatefulWidget {
   /// Set the layout margins for the Mapbox Compass
   final Point? compassViewMargins;
 
-  /// Set the layout margins for the Mapbox Attribution Buttons
+  /// Set the position for the Mapbox Attribution Button
+  final AttributionButtonPosition? attributionButtonPosition;
+
+  /// Set the layout margins for the Mapbox Attribution Buttons. If you set this
+  /// value, you may also want to set [attributionButtonPosition] to harmonize
+  /// the layout between iOS and Android, since the underlying frameworks have
+  /// different defaults.
   final Point? attributionButtonMargins;
 
   /// Which gestures should be consumed by the map.
@@ -299,6 +306,7 @@ class _MapboxMapOptions {
     this.logoViewMargins,
     this.compassViewPosition,
     this.compassViewMargins,
+    this.attributionButtonPosition,
     this.attributionButtonMargins,
   });
 
@@ -319,6 +327,7 @@ class _MapboxMapOptions {
       logoViewMargins: map.logoViewMargins,
       compassViewPosition: map.compassViewPosition,
       compassViewMargins: map.compassViewMargins,
+      attributionButtonPosition: map.attributionButtonPosition,
       attributionButtonMargins: map.attributionButtonMargins,
     );
   }
@@ -352,6 +361,8 @@ class _MapboxMapOptions {
   final CompassViewPosition? compassViewPosition;
 
   final Point? compassViewMargins;
+
+  final AttributionButtonPosition? attributionButtonPosition;
 
   final Point? attributionButtonMargins;
 
@@ -387,6 +398,7 @@ class _MapboxMapOptions {
     addIfNonNull('logoViewMargins', pointToArray(logoViewMargins));
     addIfNonNull('compassViewPosition', compassViewPosition?.index);
     addIfNonNull('compassViewMargins', pointToArray(compassViewMargins));
+    addIfNonNull('attributionButtonPosition', attributionButtonPosition?.index);
     addIfNonNull(
         'attributionButtonMargins', pointToArray(attributionButtonMargins));
     return optionsMap;

--- a/mapbox_gl_platform_interface/lib/src/ui.dart
+++ b/mapbox_gl_platform_interface/lib/src/ui.dart
@@ -67,6 +67,14 @@ enum CompassViewPosition {
   BottomRight,
 }
 
+/// Attribution Button Position
+enum AttributionButtonPosition {
+  TopLeft,
+  TopRight,
+  BottomLeft,
+  BottomRight,
+}
+
 /// Bounds for the map camera target.
 // Used with [MapboxMapOptions] to wrap a [LatLngBounds] value. This allows
 // distinguishing between specifying an unbounded target (null `LatLngBounds`)

--- a/mapbox_gl_web/lib/src/convert.dart
+++ b/mapbox_gl_web/lib/src/convert.dart
@@ -56,14 +56,16 @@ class Convert {
           options['logoViewMargins'][0], options['logoViewMargins'][1]);
     }
     if (options.containsKey('compassViewPosition')) {
-      sink.setCompassGravity(options['compassViewPosition']);
+      final position = CompassViewPosition.values[options['compassViewPosition']];
+      sink.setCompassAlignment(position);
     }
     if (options.containsKey('compassViewMargins')) {
       sink.setCompassViewMargins(
           options['compassViewMargins'][0], options['compassViewMargins'][1]);
     }
     if (options.containsKey('attributionButtonPosition')) {
-      sink.setAttributionButtonGravity(options['attributionButtonPosition']);
+      final position = AttributionButtonPosition.values[options['attributionButtonPosition']];
+      sink.setAttributionButtonAlignment(position);
     }
     if (options.containsKey('attributionButtonMargins')) {
       sink.setAttributionButtonMargins(options['attributionButtonMargins'][0],

--- a/mapbox_gl_web/lib/src/convert.dart
+++ b/mapbox_gl_web/lib/src/convert.dart
@@ -62,6 +62,9 @@ class Convert {
       sink.setCompassViewMargins(
           options['compassViewMargins'][0], options['compassViewMargins'][1]);
     }
+    if (options.containsKey('attributionButtonPosition')) {
+      sink.setAttributionButtonGravity(options['attributionButtonPosition']);
+    }
     if (options.containsKey('attributionButtonMargins')) {
       sink.setAttributionButtonMargins(options['attributionButtonMargins'][0],
           options['attributionButtonMargins'][1]);

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -630,6 +630,11 @@ class MapboxMapController extends MapboxGlPlatform
   }
 
   @override
+  void setAttributionButtonGravity(int gravity) {
+    print('setAttributionButtonGravity not available in web');
+  }
+
+  @override
   void setCompassViewMargins(int x, int y) {
     print('setCompassViewMargins not available in web');
   }

--- a/mapbox_gl_web/lib/src/mapbox_map_controller.dart
+++ b/mapbox_gl_web/lib/src/mapbox_map_controller.dart
@@ -625,13 +625,13 @@ class MapboxMapController extends MapboxGlPlatform
   }
 
   @override
-  void setCompassGravity(int gravity) {
-    _updateNavigationControl(position: CompassViewPosition.values[gravity]);
+  void setCompassAlignment(CompassViewPosition position) {
+    _updateNavigationControl(position: position);
   }
 
   @override
-  void setAttributionButtonGravity(int gravity) {
-    print('setAttributionButtonGravity not available in web');
+  void setAttributionButtonAlignment(AttributionButtonPosition position) {
+    print('setAttributionButtonAlignment not available in web');
   }
 
   @override

--- a/mapbox_gl_web/lib/src/options_sink.dart
+++ b/mapbox_gl_web/lib/src/options_sink.dart
@@ -29,11 +29,11 @@ abstract class MapboxMapOptionsSink {
 
   void setLogoViewMargins(int x, int y);
 
-  void setCompassGravity(int gravity);
+  void setCompassAlignment(CompassViewPosition position);
 
   void setCompassViewMargins(int x, int y);
 
-  void setAttributionButtonGravity(int gravity);
+  void setAttributionButtonAlignment(AttributionButtonPosition position);
 
   void setAttributionButtonMargins(int x, int y);
 }

--- a/mapbox_gl_web/lib/src/options_sink.dart
+++ b/mapbox_gl_web/lib/src/options_sink.dart
@@ -33,5 +33,7 @@ abstract class MapboxMapOptionsSink {
 
   void setCompassViewMargins(int x, int y);
 
+  void setAttributionButtonGravity(int gravity);
+
   void setAttributionButtonMargins(int x, int y);
 }


### PR DESCRIPTION
This continues the work of PR #615 and closes #261, closes #540, and replaces
the changed calculation of #681 with a more general solution.

The underlying issue here is that the attribution button is left-aligned
by default on Android, and right-aligned by default on iOS. The approach
taken in #681 where the margin x value is assumed to represent the left
margin does not generalize to iOS, where it will be a right margin.

Since the alignment / gravity of the button can be configured on each
platform, we can address this problem at its source by exposing this
configuration through flutter-mapbox-gl. Then on Android, we can apply
the button margins same way the compass is positioned, with respect to
its gravity.

I've tested this on iOS and Android with both bottom left and bottom
right attribution buttons. The best option currently is to configure the
attribution button to bottom right, where it falls by default on iOS. In
this way you will have a similar experience on both platforms with a
fully configurable margin.

The mapbox logo's alignment/position is also configurable, should anyone
want to expose it in future.