### PR TITLE
fixed LocationTracking issue delayed permissions

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1365,15 +1365,16 @@ final class MapboxMapController
 
   @Override
   public void setMyLocationTrackingMode(int myLocationTrackingMode) {
+    if (mapboxMap != null) {
+      // ensure that location is trackable
+      updateMyLocationEnabled();
+    }
     if (this.myLocationTrackingMode == myLocationTrackingMode) {
       return;
     }
     this.myLocationTrackingMode = myLocationTrackingMode;
-    if (mapboxMap != null) {
-      updateMyLocationEnabled();
-      if (locationComponent != null) {
-        updateMyLocationTrackingMode();
-      }
+    if (mapboxMap != null && locationComponent != null) {
+      updateMyLocationTrackingMode();
     }
   }
 


### PR DESCRIPTION
On android if the users starts up the app for the first time it has no permissions to track the user location. Even if the the location tracking mode is later changed the location puck would not show because the locationComponent does not come up.

This PR fixes that by activating the locationComponent on a mode change if it hasn’t already  been activated.